### PR TITLE
[성재호]w2_리뷰요청_메일작성_컴포넌트_구현

### DIFF
--- a/review/Send_Mail/Input_Body/index.js
+++ b/review/Send_Mail/Input_Body/index.js
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+import S from './styled';
+import GS from '../styled';
+import { sendMailContext } from '../context';
+
+const InputBody = () => {
+  const { bodyComponent } = useContext(sendMailContext);
+
+  return (
+    <GS.RowWrapper>
+      <GS.Label>내용</GS.Label>
+      <S.WriteBody ref={bodyComponent} contentEditable={true} />
+    </GS.RowWrapper>
+  );
+};
+
+export default InputBody;

--- a/review/Send_Mail/Input_Body/styled.js
+++ b/review/Send_Mail/Input_Body/styled.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const WriteBody = styled.div`
+  outline: none;
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 8px;
+  height: 250px;
+  font-size: 14px;
+  overflow-y: scroll;
+`;
+
+export default { WriteBody };

--- a/review/Send_Mail/Input_Receiver/index.js
+++ b/review/Send_Mail/Input_Receiver/index.js
@@ -1,0 +1,90 @@
+import React, { useRef, useContext } from "react";
+import S from "./styled";
+import GS from "../styled";
+import V from "../../../utils/validator";
+import { sendMailContext } from "../context";
+
+const ListOfReceivers = () => {
+  const [BLANK, SPACE, BACKSPACE, ENTER, COMMA] = [
+    "",
+    " ",
+    "Backspace",
+    "Enter",
+    ","
+  ];
+
+  const { receivers, setReceivers } = useContext(sendMailContext).receiver;
+  const receiverInput = useRef(null);
+  const inputWidthGuide = useRef(null);
+
+  const focusOn = () => receiverInput.current.focus();
+  const resizeInput = target => {
+    inputWidthGuide.current.innerText = target.value;
+    target.style.width = `${inputWidthGuide.current.clientWidth + 35}px`;
+  };
+
+  const deleteByRegExp = regex => val =>
+    val.replace(new RegExp(regex, "gi"), BLANK);
+  const replaceAndSetReceiver = (f, target) => {
+    const replaced = f(target.value);
+    if (replaced !== BLANK) {
+      setReceivers([...receivers, replaced]);
+      target.value = BLANK;
+      resizeInput(target);
+    }
+  };
+
+  const keyDownHandler = e => {
+    const { key, target } = e;
+    if (key === BACKSPACE && target.value === BLANK && receivers.length > 0) {
+      target.value = receivers[receivers.length - 1];
+      setReceivers([...receivers.slice(0, -1)]);
+    } else if (key === ENTER && target.value !== BLANK) {
+      replaceAndSetReceiver(deleteByRegExp(COMMA), target);
+    }
+  };
+
+  const changeHandler = e => {
+    const { target } = e;
+    resizeInput(target);
+    if (target.value.includes(COMMA) && target.value !== COMMA) {
+      replaceAndSetReceiver(deleteByRegExp(COMMA), target);
+    } else if (target.value.includes(SPACE) && target.value !== SPACE) {
+      replaceAndSetReceiver(deleteByRegExp(SPACE), target);
+    }
+  };
+
+  const getReceiverLis = () =>
+    receivers.map((receiver, idx) => (
+      <S.ReceiverListLi validation={V.validate("email", receiver)} key={idx}>
+        {receiver}
+        <S.ReceiverLiDeleteBtn
+          onClick={() =>
+            setReceivers([
+              ...receivers.filter(receivr => receivers.indexOf(receivr) !== idx)
+            ])
+          }
+        >
+          X
+        </S.ReceiverLiDeleteBtn>
+      </S.ReceiverListLi>
+    ));
+
+  return (
+    <GS.RowWrapper>
+      <GS.Label>받는 사람</GS.Label>
+      <S.ReceiverListWrapper onClick={focusOn}>
+        <S.ReceiverInputWidthGuide ref={inputWidthGuide} />
+        <S.ReceiverListUl>{getReceiverLis()}</S.ReceiverListUl>
+        <S.ReceiverListInput
+          ref={receiverInput}
+          onKeyDown={keyDownHandler}
+          onChange={changeHandler}
+          contentEditable={true}
+        />
+      </S.ReceiverListWrapper>
+    </GS.RowWrapper>
+  );
+};
+
+export default ListOfReceivers;

--- a/review/Send_Mail/Input_Receiver/styled.js
+++ b/review/Send_Mail/Input_Receiver/styled.js
@@ -1,0 +1,80 @@
+import styled from 'styled-components';
+
+const ReceiverListWrapper = styled.div`
+  min-height: 29px;
+  padding: 5px 5px;
+  border: 1px solid black;
+  border-radius: 5px;
+  overflow: auto;
+  cursor: text;
+`;
+
+const ReceiverListUl = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+`;
+
+const ReceiverListLi = styled.li`
+  margin-right: 3px;
+  float: left;
+  padding: 5px 5px 2px 5px;
+  border: 1px solid grey;
+  border-radius: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  word-break: break-all;
+  width: auto;
+  min-height: 20px;
+  font-size: 14px;
+  background-color: ${props => (props.validation ? 'white' : '#D93024')};
+  color: ${props => (props.validation ? 'black' : '#FDEFEF')};
+`;
+
+const ReceiverLiDeleteBtn = styled.div`
+  margin-left: 5px;
+  width: 20px;
+  height: 20px;
+  border-radius: 100px;
+  outline: none;
+  text-align: center;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ReceiverListInput = styled.input`
+  width: 20px;
+  margin-top: 3px;
+  float: left;
+  min-height: 16px;
+  border: none;
+  padding: 5px 5px 2px 5px;
+  font-size: 14px;
+  max-width: 485px;
+  padding-right: 10px;
+`;
+
+const ReceiverInputWidthGuide = styled.div`
+  display: inline-block;
+  width: auto;
+  height: auto;
+  font-size: 14px;
+  white-space: nowrap;
+  position: absolute;
+  left: -1000px;
+  top: -1000px;
+`;
+
+export default {
+  ReceiverListWrapper,
+  ReceiverListUl,
+  ReceiverListLi,
+  ReceiverLiDeleteBtn,
+  ReceiverListInput,
+  ReceiverInputWidthGuide,
+};

--- a/review/Send_Mail/Input_Subject/index.js
+++ b/review/Send_Mail/Input_Subject/index.js
@@ -1,0 +1,16 @@
+import React, { useContext } from 'react';
+import S from './styled';
+import GS from '../styled';
+import { sendMailContext } from '../context';
+
+const InputSubject = () => {
+  const { subjectComponent } = useContext(sendMailContext);
+  return (
+    <GS.RowWrapper>
+      <GS.Label>제목</GS.Label>
+      <S.InputSubject ref={subjectComponent} maxLength={50} />
+    </GS.RowWrapper>
+  );
+};
+
+export default InputSubject;

--- a/review/Send_Mail/Input_Subject/styled.js
+++ b/review/Send_Mail/Input_Subject/styled.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const InputSubject = styled.input`
+  min-height: 29px;
+  padding: 8px;
+  border: 1px solid black;
+  border-radius: 5px;
+  font-size: 14px;
+  outline: none;
+`;
+
+export default { InputSubject };

--- a/review/Send_Mail/Submit_Button/index.js
+++ b/review/Send_Mail/Submit_Button/index.js
@@ -1,0 +1,81 @@
+import React, { useContext } from 'react';
+import Button from '@material-ui/core/Button';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Grow from '@material-ui/core/Grow';
+import Paper from '@material-ui/core/Paper';
+import Popper from '@material-ui/core/Popper';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
+import SendIcon from '@material-ui/icons/Send';
+import { sendMailContext } from '../context';
+import GS from '../styled';
+
+const SubmitButton = () => {
+  const { receivers } = useContext(sendMailContext).receiver;
+  const { subjectComponent, bodyComponent } = useContext(sendMailContext);
+  const [open, setOpen] = React.useState(false);
+  const anchorRef = React.useRef(null);
+
+  const handleClick = () => {
+    console.info('보내기 클릭');
+    console.log(receivers);
+    console.log(subjectComponent.current.value);
+    console.log(bodyComponent.current.innerText);
+  };
+
+  const handleMenuItemClick = event => {
+    console.log('보내기 예약 클릭');
+    console.log(receivers);
+    console.log(subjectComponent.current.value);
+    console.log(bodyComponent.current.innerText);
+    setOpen(false);
+  };
+
+  const handleToggle = () => {
+    setOpen(prevOpen => !prevOpen);
+  };
+
+  const handleClose = event => {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+    setOpen(false);
+  };
+
+  return (
+    <GS.RowWrapper>
+      <div></div>
+      <div>
+        <ButtonGroup variant="outlined" color="default" ref={anchorRef}>
+          <Button onClick={handleClick}>보내기</Button>
+          <Button color="default" size="small" onClick={handleToggle}>
+            <ArrowDropDownIcon />
+          </Button>
+        </ButtonGroup>
+        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
+          {({ TransitionProps, placement }) => (
+            <Grow
+              {...TransitionProps}
+              style={{
+                transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+              }}>
+              <Paper>
+                <ClickAwayListener onClickAway={handleClose}>
+                  <MenuList id="split-button-menu">
+                    <MenuItem onClick={event => handleMenuItemClick(event)}>
+                      {<SendIcon fontSize="small" />} 보내기 예약
+                    </MenuItem>
+                  </MenuList>
+                </ClickAwayListener>
+              </Paper>
+            </Grow>
+          )}
+        </Popper>
+      </div>
+    </GS.RowWrapper>
+  );
+};
+
+export default SubmitButton;

--- a/review/Send_Mail/Submit_Button/styled.js
+++ b/review/Send_Mail/Submit_Button/styled.js
@@ -1,0 +1,1 @@
+import styled from 'styled-components';

--- a/review/Send_Mail/context/index.js
+++ b/review/Send_Mail/context/index.js
@@ -1,0 +1,21 @@
+import React, { useState, useRef } from 'react';
+
+export const sendMailContext = React.createContext();
+
+const sendMailContextProvider = ({ children }) => {
+  const [receivers, setReceivers] = useState([]);
+  const subjectComponent = useRef(null);
+  const bodyComponent = useRef(null);
+
+  const props = {
+    value: {
+      receiver: { receivers, setReceivers },
+      subjectComponent,
+      bodyComponent,
+    },
+  };
+
+  return <sendMailContext.Provider {...props}>{children}</sendMailContext.Provider>;
+};
+
+export default sendMailContextProvider;

--- a/review/Send_Mail/index.js
+++ b/review/Send_Mail/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import S from './styled';
+import InputReceiver from './Input_Receiver';
+import InputSubject from './Input_Subject';
+import InputBody from './Input_Body';
+import SubmitButton from './Submit_Button';
+import SendMailContextProvider from './context';
+
+const SendMail = () => (
+  <SendMailContextProvider>
+    <S.DivWrite>
+      <InputReceiver />
+      <InputSubject />
+      <InputBody />
+      <SubmitButton />
+    </S.DivWrite>
+  </SendMailContextProvider>
+);
+
+export default SendMail;

--- a/review/Send_Mail/styled.js
+++ b/review/Send_Mail/styled.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+const Label = styled.div`
+  font-size: 15px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const RowWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 75px 500px;
+`;
+
+const DivWrite = styled.div`
+  display: grid;
+  grid-row-gap: 8px;
+`;
+
+export default { Label, RowWrapper, DivWrite };


### PR DESCRIPTION
### 개발 상황
현재 사이드와 헤더 레이아웃이 존재하고, 메인 레이아웃에 들어갈 메일 작성 파트의 컴포넌트를 구현하고 있습니다.

### 궁금한 사항
1. 네이버의 메일 보내기 페이지에서 메일을 받을 사람의 메일주소를 입력하는 부분에 메일주소를 입력하다보면 input의 width가 입력된 text 한글자 한글자마다의 width만큼 넓어지는 부분을 똑같이 구현해보고자 하고 있습니다. 
찾은 방법은 두가지가 있었는데요. 
하나는 입력부분엔 input 태그를 두고 div태그를 화면에 보이지 않게 저 멀리 보내서 input에서 onchange 액션이 발생할 때마다 div 태그에 input 태그의 value를 innerText로 넣어준 후 div 태그의 clientWidth를 받아서 input태그의 width를 변경시켜주는 방법,
다른 하나는 div태그에 editable 속성을 true로 주어서 CSS를 활용하는 방법 이렇게 두가지였습니다. 
두가지 방법 다 사용해보았는데 구현하는데에는 두번째 방법이 편했지만 현재는 네이버를 따라 첫번째 방법으로 구현하였습니다. 
이 두가지 방법중 어느 방법이 best-practice인지 궁금합니다!

2. 리액트를 제대로 공부하기 시작한 시간이 많이 짧습니다. 코드의 전체적인 스타일이나 조금 더 리액트스러운 코드로 보완하면 좋을 부분을 지적해주시면 감사하겠습니다!