### PR TITLE
fix: remove is_removed, add is_default

### DIFF
--- a/server/mock/create-large-amount-data.js
+++ b/server/mock/create-large-amount-data.js
@@ -23,7 +23,6 @@ const bulkCreateMail = async () => {
       mail_template_id: (i % 10) + 1,
       is_read: i % 2 === 0,
       is_important: i % 3 === 0,
-      is_removed: i % 5 === 0,
     };
     mails.push(mail);
   }

--- a/server/src/database/models/category.js
+++ b/server/src/database/models/category.js
@@ -15,6 +15,11 @@ const model = (sequelize, DataTypes) => {
         type: DataTypes.STRING(255),
         unique: true,
       },
+      is_default: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      },
     },
     {
       freezeTableName: true,

--- a/server/src/database/models/classification-pattern.js
+++ b/server/src/database/models/classification-pattern.js
@@ -26,8 +26,7 @@ const model = (sequelize, DataTypes) => {
     },
   );
 
-  ClassificationPattern.associate = ({ Category, ClassificationPatternType }) => {
-    Category.belongsTo(ClassificationPatternType, { foreignKey: 'category_no', targetKey: 'no' });
+  ClassificationPattern.associate = ({ Category }) => {
     ClassificationPattern.belongsTo(Category, { foreignKey: 'category_no', targetKey: 'no' });
   };
 

--- a/server/src/database/models/mail.js
+++ b/server/src/database/models/mail.js
@@ -33,11 +33,6 @@ const model = (sequelize, DataTypes) => {
         allowNull: false,
         defaultValue: false,
       },
-      is_removed: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-        defaultValue: false,
-      },
     },
     {
       freezeTableName: true,

--- a/server/test/mail/database.bulk.spec.js
+++ b/server/test/mail/database.bulk.spec.js
@@ -45,56 +45,37 @@ describe('Mail bulk query test', () => {
     const filteredMails = unreadMails.filter(mail => mail.is_read);
     filteredMails.should.have.length(0);
   });
+});
 
-  it('휴지통에는 is_removed가 true인 메일만 존재한다.', async () => {
-    const email = 'root@daitnu.com';
-    const userNo = 1;
+it('카테고리 메일함에는 지정된 카테고리No mail만 존재한다.', async () => {
+  const email = 'root@daitnu.com';
+  const userNo = 1;
+  const categoryNo = 1;
 
-    const mailFilter = {
-      is_removed: true,
-    };
-    const mailTemplateFilter = {
-      from: {
-        [DB.Sequelize.Op.not]: email,
-      },
-    };
+  const mailFilter = {
+    category_no: categoryNo,
+  };
+  const mailTemplateFilter = {
+    from: {
+      [DB.Sequelize.Op.not]: email,
+    },
+  };
 
-    const trashCan = await DB.Mail.findAllFilteredMail(userNo, mailFilter, mailTemplateFilter);
-    const filteredMails = trashCan.filter(mail => !mail.is_removed);
-    filteredMails.should.have.length(0);
-  });
+  const categoryMails = await DB.Mail.findAllFilteredMail(userNo, mailFilter, mailTemplateFilter);
+  const filteredMails = categoryMails.filter(mail => mail.category_no !== categoryNo);
+  filteredMails.should.have.length(0);
+});
 
-  it('카테고리 메일함에는 지정된 카테고리No mail만 존재한다.', async () => {
-    const email = 'root@daitnu.com';
-    const userNo = 1;
-    const categoryNo = 1;
+it('메일에 attachment가 있다면 모두 포함되어 반환된다..', async () => {
+  const userNo = 1;
 
-    const mailFilter = {
-      category_no: categoryNo,
-    };
-    const mailTemplateFilter = {
-      from: {
-        [DB.Sequelize.Op.not]: email,
-      },
-    };
+  const mailFilter = {};
+  const mailTemplateFilter = {
+    no: 1,
+  };
 
-    const categoryMails = await DB.Mail.findAllFilteredMail(userNo, mailFilter, mailTemplateFilter);
-    const filteredMails = categoryMails.filter(mail => mail.category_no !== categoryNo);
-    filteredMails.should.have.length(0);
-  });
-
-  it('메일에 attachment가 있다면 모두 포함되어 반환된다..', async () => {
-    const userNo = 1;
-
-    const mailFilter = {};
-    const mailTemplateFilter = {
-      no: 1,
-    };
-
-    const mail = await DB.Mail.findAllFilteredMail(userNo, mailFilter, mailTemplateFilter, {
-      limit: 1,
-      raw: false,
-    });
-    mail[0].dataValues.MailTemplate.Attachments.should.have.length(5);
+  const mail = await DB.Mail.findAllFilteredMail(userNo, mailFilter, mailTemplateFilter, {
+    limit: 1,
+    raw: false,
   });
 });

--- a/server/test/mail/database.spec.js
+++ b/server/test/mail/database.spec.js
@@ -38,7 +38,6 @@ describe('Mail DB query Test', () => {
         mail_template_id: 1,
         is_important: false,
         is_read: false,
-        is_removed: false,
       });
     });
   });

--- a/server/test/mail/service.spec.js
+++ b/server/test/mail/service.spec.js
@@ -25,7 +25,6 @@ describe('Mail Service Test', () => {
       'mail_template_id',
       'is_important',
       'is_read',
-      'is_removed',
       'MailTemplate',
     ]);
   });


### PR DESCRIPTION
mail 테이블에서 더 이상 필요하지 않은 is_removed 삭제
category에서 default로 존재하는 category인지 아닌지 판단하기 위해 추가

### 무엇을 (What)
1. mail 테이블의 is_removed 삭제
2. category 테이블에 is_default 추가

### 왜 그 방법을 선택했는가? (Why)
1. 휴지통도 카테고리로 구분하기로 하여 더 이상 필요하지 않음
2. 해당 카테고리가 default인지 아닌지 분리하기 위해 추가

### 리뷰어 참고사항
is_removed가 있는 테스크 코드 전부 삭제
category 테이블의 category_no 칼럼이 생성되지 않도록 수정