### PR TITLE
sequelize의 build를 통한 validation을 하기 전 이름의 좌우 공백제거, 테스트코드 변경

### DIFF
--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -2,10 +2,11 @@ import DB from '../../database';
 import getErrorResponseBySequelizeValidationError from '../exception/sequelize-error-parser';
 
 const join = async body => {
+  if (body.name) {
+    body.name = body.name.trim();
+  }
+
   try {
-    if (body.name) {
-      body.name = body.name.trim();
-    }
     await DB.User.build(body).validate();
   } catch (error) {
     throw getErrorResponseBySequelizeValidationError(error);

--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -3,6 +3,9 @@ import getErrorResponseBySequelizeValidationError from '../exception/sequelize-e
 
 const join = async body => {
   try {
+    if (body.name) {
+      body.name = body.name.trim();
+    }
     await DB.User.build(body).validate();
   } catch (error) {
     throw getErrorResponseBySequelizeValidationError(error);

--- a/server/test/mail/database.bulk.spec.js
+++ b/server/test/mail/database.bulk.spec.js
@@ -7,7 +7,9 @@ import bulkMock from '../../mock/create-large-amount-data';
 
 describe('Mail bulk query test', () => {
   before(async () => {
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
     await DB.sequelize.sync({ force: true });
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
     await mock();
     await bulkMock();
   });

--- a/server/test/mail/database.spec.js
+++ b/server/test/mail/database.spec.js
@@ -6,7 +6,9 @@ import mock from '../../mock/create-dummy-data';
 const rootEmail = 'root@daitnu.com';
 describe('Mail DB query Test', () => {
   before(async () => {
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
     await DB.sequelize.sync({ force: true });
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
     await mock();
   });
 

--- a/server/test/mail/service.spec.js
+++ b/server/test/mail/service.spec.js
@@ -7,7 +7,9 @@ import mock from '../../mock/create-dummy-data';
 const root2Email = 'root2@daitnu.com';
 describe('Mail Service Test', () => {
   before(async () => {
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
     await DB.sequelize.sync({ force: true });
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
     await mock();
   });
 

--- a/server/test/mail_template/database.spec.js
+++ b/server/test/mail_template/database.spec.js
@@ -4,7 +4,9 @@ import DB from '../../src/database';
 
 describe('MailTemplate DB test...', () => {
   before(async () => {
-    DB.sequelize.sync({ force: true });
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
+    await DB.sequelize.sync({ force: true });
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
   });
 
   it('create test', async () => {

--- a/server/test/user/api.spec.js
+++ b/server/test/user/api.spec.js
@@ -24,8 +24,8 @@ describe('회원등록 POST /users는...', () => {
   before(async () => {
     await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
     await DB.sequelize.sync({ force: true });
-    await mock();
     await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
+    await mock();
   });
 
   it('# 성공할 경우 상태코드는 201이며 json을 리턴한다.', done => {
@@ -63,6 +63,16 @@ describe('회원등록 POST /users는...', () => {
       .send({
         ...user1,
         password: 'test',
+      })
+      .expect(400, done);
+  });
+
+  it('이름을 공백으로 줄 경우 상태코드는 400이다.', done => {
+    request(app)
+      .post('/v1/users')
+      .send({
+        ...user1,
+        name: '  ',
       })
       .expect(400, done);
   });

--- a/server/test/user/database.spec.js
+++ b/server/test/user/database.spec.js
@@ -12,7 +12,9 @@ const user = {
 
 describe('User DB Test..', () => {
   before(async () => {
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
     await DB.sequelize.sync({ force: true });
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
   });
   describe('Validate Test...', () => {
     describe('userid validate는..', () => {

--- a/server/test/user/service.spec.js
+++ b/server/test/user/service.spec.js
@@ -24,8 +24,8 @@ describe('user service는...', () => {
   before(async () => {
     await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
     await DB.sequelize.sync({ force: true });
-    await mock();
     await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
+    await mock();
   });
 
   describe('register 함수는...', () => {


### PR DESCRIPTION
### 무엇을 (What)
1. sequelize의 build를 통한 validation전 이름의 좌우 공백제거
2. 테스트 코드 테이블 초기화시 외래키 제약조건을 제거

### 왜 그 방법을 선택했는가? (Why)
1. 사용자가 실수로 띄어쓰기를 넣어 요청을 할 수도 있을 것 같아서 trim을 사용하여 좌우 공백 제거
2. 이름에 공백문자만 넣어서 건네줄 경우 에러로 간주해야 함
3. 데이터베이스에 남아있는 테이블의 row들이 서로 외래키로 참조하고 잇는 경우가 있어 삭제되지 않아 문제가 발생하는 경우가 있어서 초기화시 외래키 제약조건 제거

### 리뷰어 참고사항
1. validation/user.js의 join 함수에서 body.name이 존재할 경우 body.name을 trim을 시켜주도록 함