### PR TITLE
[server] 페이징처리시 category가 0일때 category를 필터에서 제거

### DIFF
--- a/server/src/libraries/validation/mail.js
+++ b/server/src/libraries/validation/mail.js
@@ -4,17 +4,18 @@ import ErrorField from '../exception/error-field';
 import ErrorResponse from '../exception/error-response';
 
 const { MAX_SAFE_INTEGER } = Number;
-const NUMBER_RAGE = { min: 1, max: MAX_SAFE_INTEGER };
+const PAGE_NUMBER_RAGE = { min: 1, max: MAX_SAFE_INTEGER };
+const CATEGORY_NUMBER_RAGE = { min: 0, max: MAX_SAFE_INTEGER };
 
 const checkQuery = ({ category, page }) => {
   const errorFields = [];
 
-  if (!isInt(category, NUMBER_RAGE)) {
+  if (!isInt(category, CATEGORY_NUMBER_RAGE)) {
     const errorField = new ErrorField('category', category, '유효하지 않은 값입니다.');
     errorFields.push(errorField);
   }
 
-  if (!isInt(page, NUMBER_RAGE)) {
+  if (!isInt(page, PAGE_NUMBER_RAGE)) {
     const errorField = new ErrorField('page', page, '유효하지 않은 값입니다.');
     errorFields.push(errorField);
   }

--- a/server/src/libraries/validation/mail.js
+++ b/server/src/libraries/validation/mail.js
@@ -4,18 +4,18 @@ import ErrorField from '../exception/error-field';
 import ErrorResponse from '../exception/error-response';
 
 const { MAX_SAFE_INTEGER } = Number;
-const PAGE_NUMBER_RAGE = { min: 1, max: MAX_SAFE_INTEGER };
-const CATEGORY_NUMBER_RAGE = { min: 0, max: MAX_SAFE_INTEGER };
+const PAGE_NUMBER_RANGE = { min: 1, max: MAX_SAFE_INTEGER };
+const CATEGORY_NUMBER_RANGE = { min: 0, max: MAX_SAFE_INTEGER };
 
 const checkQuery = ({ category, page }) => {
   const errorFields = [];
 
-  if (!isInt(category, CATEGORY_NUMBER_RAGE)) {
+  if (!isInt(category, CATEGORY_NUMBER_RANGE)) {
     const errorField = new ErrorField('category', category, '유효하지 않은 값입니다.');
     errorFields.push(errorField);
   }
 
-  if (!isInt(page, PAGE_NUMBER_RAGE)) {
+  if (!isInt(page, PAGE_NUMBER_RANGE)) {
     const errorField = new ErrorField('page', page, '유효하지 않은 값입니다.');
     errorFields.push(errorField);
   }

--- a/server/src/v1/mail/controller.js
+++ b/server/src/v1/mail/controller.js
@@ -10,7 +10,7 @@ import checkQuery from '../../libraries/validation/mail';
 const list = async (req, res, next) => {
   const userNo = req.user.no;
   const { query } = req;
-  query.category = query.category || '1';
+  query.category = query.category || '0';
   query.page = query.page || '1';
 
   let mails;

--- a/server/src/v1/mail/service.js
+++ b/server/src/v1/mail/service.js
@@ -84,4 +84,4 @@ const sendMail = async mailContents => {
   return mailContents;
 };
 
-export default { getMailsByOptions, sendMail };
+export default { getMailsByOptions, sendMail, getQueryByOptions };

--- a/server/src/v1/mail/service.js
+++ b/server/src/v1/mail/service.js
@@ -6,9 +6,28 @@ import U from '../../libraries/mail-util';
 import getPaging from '../../libraries/paging';
 
 const DEFAULT_MAIL_QUERY_OPTIONS = {
-  category: 1,
+  category: 0,
   page: 1,
   perPageNum: 100,
+};
+
+const getQueryByOptions = ({ userNo, category, perPageNum, page }) => {
+  const query = {
+    userNo,
+    options: {
+      raw: false,
+    },
+    paging: {
+      limit: perPageNum,
+      offset: (page - 1) * perPageNum,
+    },
+  };
+
+  if (category > 0) {
+    query.category_no = category;
+  }
+
+  return query;
 };
 
 const getMailsByOptions = async (userNo, options = {}) => {
@@ -19,17 +38,7 @@ const getMailsByOptions = async (userNo, options = {}) => {
   page = Number(page);
   perPageNum = Number(perPageNum);
 
-  const query = {
-    userNo,
-    category_no: category,
-    options: {
-      raw: false,
-    },
-    paging: {
-      limit: perPageNum,
-      offset: (page - 1) * perPageNum,
-    },
-  };
+  const query = getQueryByOptions({ userNo, category, perPageNum, page });
   const { count: totalCount, rows: mails } = await DB.Mail.findAndCountAllFilteredMail(query);
 
   const pagingOptions = {
@@ -39,7 +48,7 @@ const getMailsByOptions = async (userNo, options = {}) => {
   const pagingResult = getPaging(totalCount, pagingOptions);
 
   return {
-    ...pagingResult,
+    paging: { ...pagingResult },
     mails,
   };
 };

--- a/server/test/libraries/mail/quey.spec.js
+++ b/server/test/libraries/mail/quey.spec.js
@@ -35,15 +35,6 @@ describe('checkQuery....', () => {
     }
   });
 
-  it("# category가 0이면 errorField reason은 '유효하지 않은 값입니다.' 이다.", () => {
-    try {
-      checkQuery({ ...data, category: '0' });
-    } catch (err) {
-      const { fieldErrors } = err;
-      fieldErrors[0].reason.should.be.equals('유효하지 않은 값입니다.');
-    }
-  });
-
   it("# category가 음수이면 errorField reason은 '유효하지 않은 값입니다.' 이다.", () => {
     try {
       checkQuery({ ...data, category: '-1' });

--- a/server/test/mail/api.spec.js
+++ b/server/test/mail/api.spec.js
@@ -89,16 +89,16 @@ describe('Mail api test...', () => {
           .expect(200, done);
       });
 
+      it('# category를 0으로 요청시 status는 200이다', done => {
+        authenticatedUser.get('/v1/mail?category=0').expect(200, done);
+      });
+
       it('# 메일리스트 요청시 status코드는 200이다', done => {
         authenticatedUser.get('/v1/mail').expect(200, done);
       });
 
       it('# category를 음수로 요청시 status는 400이다', done => {
         authenticatedUser.get('/v1/mail?category=-1').expect(400, done);
-      });
-
-      it('# category를 0으로 요청시 status는 400이다', done => {
-        authenticatedUser.get('/v1/mail?category=0').expect(400, done);
       });
 
       it('# page를 0으로 요청시 status는 400이다', done => {

--- a/server/test/mail/service.spec.js
+++ b/server/test/mail/service.spec.js
@@ -14,31 +14,52 @@ describe('Mail Service Test', () => {
     await bulkMock();
   });
 
-  it('getMailsByOptions 페이징 정보를 포함한다.', async () => {
-    const data = await service.getMailsByOptions(1, {});
-    data.should.be.properties('startPage', 'endPage', 'page', 'perPageNum', 'totalPage');
+  describe('getMailsByOptions...', () => {
+    it('# 페이징 정보를 포함한다.', async () => {
+      const data = await service.getMailsByOptions(1, {});
+      data.paging.should.be.properties('startPage', 'endPage', 'page', 'perPageNum', 'totalPage');
+    });
+
+    it('# 메일리스트 정보를 배열로 포함한다.', async () => {
+      const data = await service.getMailsByOptions(1, {});
+      data.mails.should.an.instanceof(Array);
+    });
+
+    it('# perPageNum만큼 mail을 반환한다.', async () => {
+      const options = {
+        perPageNum: 2,
+      };
+      const data = await service.getMailsByOptions(1, options);
+      data.mails.should.have.length(2);
+    });
+
+    it('# category에 해당하는 메일들을 반환한다.', async () => {
+      const category = 10;
+      const options = {
+        category,
+      };
+      const { mails } = await service.getMailsByOptions(1, options);
+      const length = mails.filter(mail => mail.category_no === category);
+      length.should.have.length(0);
+    });
   });
 
-  it('getMailsByOptions 메일리스트 정보를 배열로 포함한다.', async () => {
-    const data = await service.getMailsByOptions(1, {});
-    data.mails.should.an.instanceof(Array);
-  });
+  describe('getQueryByOptions...', () => {
+    const data = { userNo: 1, category: 0, perPageNum: 10, page: 1 };
 
-  it('getMailsByOptions perPageNum만큼 mail을 반환한다.', async () => {
-    const options = {
-      perPageNum: 2,
-    };
-    const data = await service.getMailsByOptions(1, options);
-    data.mails.should.have.length(2);
-  });
+    it('# category가 0이면 category가 포함되지 않는다.', () => {
+      const query = service.getQueryByOptions(data);
+      query.should.not.have.property('category_no');
+    });
 
-  it('getMailsByOptions는 category에 해당하는 메일들을 반환한다.', async () => {
-    const category = 10;
-    const options = {
-      category,
-    };
-    const { mails } = await service.getMailsByOptions(1, options);
-    const length = mails.filter(mail => mail.category_no === category);
-    length.should.have.length(0);
+    it('# category가 음수이면 category가 포함되지 않는다.', () => {
+      const query = service.getQueryByOptions(data);
+      query.should.not.have.property('category_no');
+    });
+
+    it('# category가 양수이면 category가 포함된다.', () => {
+      const query = service.getQueryByOptions({ ...data, category: 1 });
+      query.should.have.property('category_no');
+    });
   });
 });


### PR DESCRIPTION
### 무엇을 (What)
1. mail service계층에 getMailsByOptions함수에서 category가 0이면 db query filter에서 category제거함으로써 전체 메일함 쿼리로 만듬
2. getQueryByOptions 함수를 통해 category 값에 따른 query를 얻을 수 있도록 함수 분리

### 왜 그 방법을 선택했는가? (Why)
1. 유연한 확장을 위해 분리
2. 재활용 가능하도록함

### 리뷰어 참고사항