### PR TITLE
[BE] 아이디 찾기 API 구현

### DIFF
--- a/server/src/database/models/user.js
+++ b/server/src/database/models/user.js
@@ -110,6 +110,15 @@ const model = (sequelize, DataTypes) => {
     });
   };
 
+  User.findOneByEmail = email => {
+    return User.findOne({
+      where: {
+        sub_email: email,
+      },
+      raw: true,
+    });
+  };
+
   User.beforeBulkCreate(async instances => {
     for (const instance of instances) {
       await convertToUserModel(instance);

--- a/server/src/database/models/user.js
+++ b/server/src/database/models/user.js
@@ -2,14 +2,17 @@
 /* eslint-disable camelcase */
 /* eslint-disable no-await-in-loop */
 import bcrypt from 'bcrypt';
+import crypto from 'crypto';
 
-const { SALT_ROUND, DEFAULT_DOMAIN_NAME } = process.env;
+const { DEFAULT_DOMAIN_NAME } = process.env;
 
 const convertToUserModel = async instance => {
   const { id, password } = instance.dataValues;
-  const round = parseInt(SALT_ROUND, 10);
-  const salt = await bcrypt.genSalt(round);
-  const hashedPassword = await bcrypt.hash(password, salt);
+
+  const hashedPassword = crypto
+    .createHash('sha512')
+    .update(password)
+    .digest('base64');
   instance.email = `${id}@${DEFAULT_DOMAIN_NAME}`;
   instance.password = hashedPassword;
 };

--- a/server/src/libraries/exception/error-code.js
+++ b/server/src/libraries/exception/error-code.js
@@ -31,6 +31,7 @@ const ERROR_CODE = {
     '가입하지 않은 아이디이거나, 잘못된 비밀번호입니다.',
     'LOGIN001',
   ),
+  EMAIL_NOT_FOUND: $(404, '가입된 적 없는 이메일 입니다.', 'COMMON009'),
   ID_DUPLICATION: $(409, '이미 사용중인 아이디 입니다.', 'JOIN001'),
   EMAIL_DUPLICATION: $(409, '이미 가입에 사용한 이메일 입니다.', 'JOIN002'),
 

--- a/server/src/libraries/mail-util.js
+++ b/server/src/libraries/mail-util.js
@@ -1,3 +1,6 @@
+import nodemailer from 'nodemailer';
+import replace from './replace';
+
 const { DEFAULT_DOMAIN_NAME, MAIL_AUTH_USER, MAIL_AUTH_PASS, SMTP_PORT } = process.env;
 
 const getSingleMailData = ({ from, to, subject, text, attachments = [] }) => {
@@ -29,7 +32,42 @@ const getTransport = () => {
   };
 };
 
+const makeFindIdMailHtml = id => {
+  return `
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+KR&display=swap" rel="stylesheet">
+    <h1 style="font-family: 'Noto Sans KR', sans-serif;">요청하신 아이디를</h1>
+    <h1 style="color: #3742fa; font-family: 'Noto Sans KR', sans-serif;">알려드립니다.</h1>
+    <img src="https://user-images.githubusercontent.com/33617083/68571001-457a9d80-04a5-11ea-9a47-98c0fd36a1d9.png"/>
+    <p style="font-family: 'Noto Sans KR', sans-serif;"><span style="font-size: 20px; margin-left: 5px; font-weight: bold">아이디: </span><span style="color: #3742fa; font-size: 20px; font-weight: bold;">${id}</span></p>
+    <br>
+    <p style="font-size: 16px; font-family: 'Noto Sans KR', sans-serif;">
+
+    Daitnu를 이용해 주셔서 감사합니다.<br>
+    더욱 편리한 서비스를 제공하기 위해 항상 최선을 다하겠습니다.<br>
+    </p>
+    </p><span style="font-style: italic;">Copyright ⓒ Daitnu Corp. All Rights Reserved.</span>`;
+};
+
+const sendFindIdMail = ({ id, email }) => {
+  const start = 1;
+  const end = 4;
+
+  id = replace.asterisk(id, start, end);
+
+  const transport = getTransport();
+  const transporter = nodemailer.createTransport(transport);
+  const mailData = {
+    from: '"Daitnu" root@daitnu.com',
+    to: email,
+    subject: '[Daitnu] 요청하신 아이디를 알려드립니다.',
+    html: makeFindIdMailHtml(id),
+  };
+
+  transporter.sendMail(mailData);
+};
+
 export default {
   getSingleMailData,
   getTransport,
+  sendFindIdMail,
 };

--- a/server/src/libraries/mail-util.js
+++ b/server/src/libraries/mail-util.js
@@ -32,7 +32,7 @@ const getTransport = () => {
   };
 };
 
-const makeFindIdMailHtml = id => {
+const createMailTemplateToFindId = id => {
   return `
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans+KR&display=swap" rel="stylesheet">
     <h1 style="font-family: 'Noto Sans KR', sans-serif;">요청하신 아이디를</h1>
@@ -48,26 +48,31 @@ const makeFindIdMailHtml = id => {
     </p><span style="font-style: italic;">Copyright ⓒ Daitnu Corp. All Rights Reserved.</span>`;
 };
 
-const sendFindIdMail = ({ id, email }) => {
-  const start = 1;
-  const end = 4;
-
-  id = replace.asterisk(id, start, end);
-
+const sendMail = data => {
   const transport = getTransport();
   const transporter = nodemailer.createTransport(transport);
+
+  transporter.sendMail(data);
+};
+
+const sendMailToFindId = ({ id, email }) => {
+  const hideStartIndex = 1;
+  const hideEndIndex = 4;
+
+  id = replace.hideIdUseAsterisk(id, hideStartIndex, hideEndIndex);
+
   const mailData = {
     from: '"Daitnu" root@daitnu.com',
     to: email,
     subject: '[Daitnu] 요청하신 아이디를 알려드립니다.',
-    html: makeFindIdMailHtml(id),
+    html: createMailTemplateToFindId(id),
   };
 
-  transporter.sendMail(mailData);
+  sendMail(mailData);
 };
 
 export default {
   getSingleMailData,
   getTransport,
-  sendFindIdMail,
+  sendMailToFindId,
 };

--- a/server/src/libraries/replace.js
+++ b/server/src/libraries/replace.js
@@ -1,4 +1,4 @@
-const asterisk = (str, start, end) => {
+const hideIdUseAsterisk = (str, start, end) => {
   const length = end - start;
   const asterisks = '*'.repeat(length);
 
@@ -6,5 +6,5 @@ const asterisk = (str, start, end) => {
 };
 
 export default {
-  asterisk,
+  hideIdUseAsterisk,
 };

--- a/server/src/libraries/replace.js
+++ b/server/src/libraries/replace.js
@@ -1,0 +1,10 @@
+const asterisk = (str, start, end) => {
+  const length = end - start;
+  const asterisks = '*'.repeat(length);
+
+  return str.replace(str.substring(start, end), asterisks);
+};
+
+export default {
+  asterisk,
+};

--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -26,7 +26,7 @@ const checkQueryForSearch = ({ type }) => {
     const errorField = new ErrorField(
       'type',
       type,
-      'type에 아이디를 찾을 경우 id나 비밀전호를 찾을 경우 pw를 넣어주어야 합니다.',
+      'type값은 아이디를 찾을 경우 "id" 비밀번호를 찾을 경우 "pw"여야 합니다.',
     );
     errorFields.push(errorField);
   }
@@ -39,18 +39,9 @@ const checkQueryForSearch = ({ type }) => {
 };
 
 const checkBodyForIdSearch = ({ email }) => {
-  const errorFields = [];
-
-  if (!email) {
-    const errorField = new ErrorField('email', email, 'email 값이 존재하지 않습니다');
-    errorFields.push(errorField);
-  } else if (!validate('email', email)) {
+  if (!email || !validate('email', email)) {
     const errorField = new ErrorField('email', email, 'email 값이 올바르지 않습니다.');
-    errorFields.push(errorField);
-  }
-
-  if (errorFields.length > 0) {
-    throw new ErrorResponse(ERROR_CODE.INVALID_INPUT_VALUE, errorFields);
+    throw new ErrorResponse(ERROR_CODE.INVALID_INPUT_VALUE, [errorField]);
   }
 
   return true;

--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -3,6 +3,7 @@ import getErrorResponseBySequelizeValidationError from '../exception/sequelize-e
 import ERROR_CODE from '../exception/error-code';
 import ErrorField from '../exception/error-field';
 import ErrorResponse from '../exception/error-response';
+import { validate } from '../validator';
 
 const join = async body => {
   if (body.name) {
@@ -21,11 +22,11 @@ const join = async body => {
 const checkQueryForSearch = ({ type }) => {
   const errorFields = [];
 
-  if (type !== 'id' && type !== 'pw') {
+  if (!type || (type !== 'id' && type !== 'pw')) {
     const errorField = new ErrorField(
       'type',
       type,
-      'type은 아이디를 찾을 경우 id, 비밀번호를 찾을 경우 pw여야 합니다.',
+      'type에 아이디를 찾을 경우 id나 비밀전호를 찾을 경우 pw를 넣어주어야 합니다.',
     );
     errorFields.push(errorField);
   }
@@ -37,4 +38,22 @@ const checkQueryForSearch = ({ type }) => {
   return true;
 };
 
-export default { join, checkQueryForSearch };
+const checkBodyForIdSearch = ({ email }) => {
+  const errorFields = [];
+
+  if (!email) {
+    const errorField = new ErrorField('email', email, 'email 값이 존재하지 않습니다');
+    errorFields.push(errorField);
+  } else if (!validate('email', email)) {
+    const errorField = new ErrorField('email', email, 'email 값이 올바르지 않습니다.');
+    errorFields.push(errorField);
+  }
+
+  if (errorFields.length > 0) {
+    throw new ErrorResponse(ERROR_CODE.INVALID_INPUT_VALUE, errorFields);
+  }
+
+  return true;
+};
+
+export default { join, checkQueryForSearch, checkBodyForIdSearch };

--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -1,5 +1,8 @@
 import DB from '../../database';
 import getErrorResponseBySequelizeValidationError from '../exception/sequelize-error-parser';
+import ERROR_CODE from '../exception/error-code';
+import ErrorField from '../exception/error-field';
+import ErrorResponse from '../exception/error-response';
 
 const join = async body => {
   if (body.name) {
@@ -15,4 +18,23 @@ const join = async body => {
   return true;
 };
 
-export default { join };
+const checkQueryForSearch = ({ type }) => {
+  const errorFields = [];
+
+  if (type !== 'id' && type !== 'pw') {
+    const errorField = new ErrorField(
+      'type',
+      type,
+      'type은 아이디를 찾을 경우 id, 비밀번호를 찾을 경우 pw여야 합니다.',
+    );
+    errorFields.push(errorField);
+  }
+
+  if (errorFields.length > 0) {
+    throw new ErrorResponse(ERROR_CODE.INVALID_INPUT_VALUE, errorFields);
+  }
+
+  return true;
+};
+
+export default { join, checkQueryForSearch };

--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -29,9 +29,6 @@ const checkQueryForSearch = ({ type }) => {
       'type값은 아이디를 찾을 경우 "id" 비밀번호를 찾을 경우 "pw"여야 합니다.',
     );
     errorFields.push(errorField);
-  }
-
-  if (errorFields.length > 0) {
     throw new ErrorResponse(ERROR_CODE.INVALID_INPUT_VALUE, errorFields);
   }
 

--- a/server/src/v1/auth/service.js
+++ b/server/src/v1/auth/service.js
@@ -1,4 +1,5 @@
 import bcrypt from 'bcrypt';
+import crypto from 'crypto';
 
 import DB from '../../database/index';
 import ERROR_CODE from '../../libraries/exception/error-code';
@@ -11,7 +12,11 @@ const localLogin = async ({ id, password }) => {
     throw new ErrorResponse(ERROR_CODE.INVALID_LOGIN_ID_OR_PASSWORD);
   }
 
-  const match = await bcrypt.compare(password, user.password);
+  const hashedPassword = crypto
+    .createHash('sha512')
+    .update(password)
+    .digest('base64');
+  const match = user.password === hashedPassword;
 
   if (!match) {
     throw new ErrorResponse(ERROR_CODE.INVALID_LOGIN_ID_OR_PASSWORD);

--- a/server/src/v1/mail/service.js
+++ b/server/src/v1/mail/service.js
@@ -39,7 +39,7 @@ const getMailsByOptions = async (userNo, options = {}) => {
   const pagingResult = getPaging(totalCount, pagingOptions);
 
   return {
-    ...pagingResult,
+    paging: pagingResult,
     mails,
   };
 };

--- a/server/src/v1/users/controller.js
+++ b/server/src/v1/users/controller.js
@@ -1,6 +1,8 @@
 import status from 'http-status';
 import validation from '../../libraries/validation/user';
 import service from './service';
+import DB from '../../database';
+import mailUtil from '../../libraries/mail-util';
 
 const registerUser = async (req, res, next) => {
   let newUser;
@@ -15,4 +17,29 @@ const registerUser = async (req, res, next) => {
   return res.status(status.CREATED).json({ newUser });
 };
 
-export default { registerUser };
+const search = async (req, res, next) => {
+  try {
+    validation.checkQueryForSearch(req.query);
+
+    switch (req.query.type) {
+      case 'id': {
+        const user = await DB.User.findOneByEmail(req.body.email);
+        if (user) {
+          mailUtil.sendFindIdMail({ id: user.user_id, email: user.sub_email });
+        }
+        break;
+      }
+      case 'pw':
+        break;
+
+      default:
+        break;
+    }
+  } catch (err) {
+    return next(err);
+  }
+
+  return res.status(status.NO_CONTENT).end();
+};
+
+export default { registerUser, search };

--- a/server/src/v1/users/controller.js
+++ b/server/src/v1/users/controller.js
@@ -1,8 +1,6 @@
 import status from 'http-status';
 import validation from '../../libraries/validation/user';
 import service from './service';
-import DB from '../../database';
-import mailUtil from '../../libraries/mail-util';
 
 const registerUser = async (req, res, next) => {
   let newUser;
@@ -23,10 +21,8 @@ const search = async (req, res, next) => {
 
     switch (req.query.type) {
       case 'id': {
-        const user = await DB.User.findOneByEmail(req.body.email);
-        if (user) {
-          mailUtil.sendFindIdMail({ id: user.user_id, email: user.sub_email });
-        }
+        validation.checkBodyForIdSearch(req.body);
+        await service.sendUserIdToEmail(req.body.email);
         break;
       }
       case 'pw':

--- a/server/src/v1/users/index.js
+++ b/server/src/v1/users/index.js
@@ -8,5 +8,6 @@ router.get('/', (req, res) => {
 });
 
 router.post('/', ctrl.registerUser);
+router.post('/search', ctrl.search);
 
 export default router;

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -43,7 +43,7 @@ const sendUserIdToEmail = async email => {
     throw new ErrorResponse(ERROR_CODE.EMAIL_NOT_FOUND);
   }
 
-  mailUtil.sendFindIdMail({ id: user.id, email: user.sub_email });
+  mailUtil.sendMailToFindId({ id: user.id, email: user.sub_email });
 
   return true;
 };

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -1,6 +1,7 @@
 import DB from '../../database';
 import ErrorResponse from '../../libraries/exception/error-response';
 import ERROR_CODE from '../../libraries/exception/error-code';
+import mailUtil from '../../libraries/mail-util';
 
 const DEFAULT_CATEGORIES = ['전체메일함', '받은메일함', '보낸메일함', '내게쓴메일함', '휴지통'];
 
@@ -35,4 +36,16 @@ const createDefaultCategories = async (no, transaction) => {
   await DB.Category.bulkCreate(categories, { transaction });
 };
 
-export default { register, createDefaultCategories };
+const sendUserIdToEmail = async email => {
+  const user = await DB.User.findOneByEmail(email);
+
+  if (!user) {
+    throw new ErrorResponse(ERROR_CODE.EMAIL_NOT_FOUND);
+  }
+
+  mailUtil.sendFindIdMail({ id: user.id, email: user.sub_email });
+
+  return true;
+};
+
+export default { register, createDefaultCategories, sendUserIdToEmail };

--- a/server/test/user/api.spec.js
+++ b/server/test/user/api.spec.js
@@ -259,13 +259,6 @@ describe('POST /users/search는...', () => {
       });
   });
 
-  it('# 아이디를 찾을 때 존재하는 메일을 넘겨줄 경우 상태코드는 204이다.', done => {
-    request(app)
-      .post('/v1/users/search?type=id')
-      .send({ email: 'daitnu@daitnu.com' })
-      .expect(204, done);
-  });
-
   it('# 아이디를 찾을 때 가입에 사용하지 않은 메일을 넘겨줄 경우 상태코드는 404이다.', done => {
     request(app)
       .post('/v1/users/search?type=id')

--- a/server/test/user/service.spec.js
+++ b/server/test/user/service.spec.js
@@ -90,4 +90,19 @@ describe('user service는...', () => {
       });
     }
   });
+
+  describe('sendUserIdToEmail 함수는...', () => {
+    it('# 가입에 사용되지 않은 이메일일 경우 ErrorResponse instance를 반환한다.', async () => {
+      try {
+        await service.sendUserIdToEmail('abcabc@zzz.zzz');
+      } catch (error) {
+        error.should.be.instanceOf(ErrorResponse);
+      }
+    });
+
+    it('# 존재하는 이메일일 경우 메일을 보내고 true를 반환한다.', async () => {
+      const result = await service.sendUserIdToEmail(user.sub_email);
+      result.should.be.true;
+    });
+  });
 });

--- a/server/test/user/service.spec.js
+++ b/server/test/user/service.spec.js
@@ -99,10 +99,5 @@ describe('user service는...', () => {
         error.should.be.instanceOf(ErrorResponse);
       }
     });
-
-    it('# 존재하는 이메일일 경우 메일을 보내고 true를 반환한다.', async () => {
-      const result = await service.sendUserIdToEmail(user.sub_email);
-      result.should.be.true;
-    });
   });
 });


### PR DESCRIPTION
### 무엇을 (What)
1. 아이디 찾기 API를 구현
2. 이메일을 찾을 수 없을 경우의 상태코드를 만듬
3. 아이디 찾기 API의 type에 부적절한 값이 들어올 경우 에러 발생

### 왜 그 방법을 선택했는가? (Why)
1. 사용자가 아이디를 찾을때 잘못된 쿼리나 이메일로 API 요청할 경우 적절한 에러 정보를 보여주기 위해서 

### 리뷰어 참고사항
1. 적절한 type 정보가 body에 있는지 확인하는 checkQueryForSearch 함수 추가
2. 적절한 email 정보가 body에 있는지 확인하는 checkBodyForIdSearch 함수 추가
3. 데이터베이스로 부터 email을 가지고 있는 유저를 찾아서 해당 유저의 email로 메일을 보내주는 sendUserIdToEmail 함수 추가