### PR TITLE
[BE] 회원가입 암호화 알고리즘 변경

### DIFF
--- a/server/src/libraries/crypto.js
+++ b/server/src/libraries/crypto.js
@@ -1,0 +1,28 @@
+import DB from '../database';
+
+export const createSalt = async () => {
+  const [saltQueryresult] = await DB.sequelize.query('SELECT SUBSTRING(SHA(RAND()), -16)', {
+    raw: true,
+    type: DB.sequelize.QueryTypes.SELECT,
+  });
+
+  const [saltKey] = Object.keys(saltQueryresult);
+  const salt = saltQueryresult[saltKey].toString();
+
+  return salt;
+};
+
+export const encrypt = async (password, salt) => {
+  const [passQueryResult] = await DB.sequelize.query(
+    `SELECT ENCRYPT('${password}', CONCAT('$6$', '${salt}'))`,
+    {
+      raw: true,
+      type: DB.sequelize.QueryTypes.SELECT,
+    },
+  );
+
+  const [passKey] = Object.keys(passQueryResult);
+  const hashedPassword = passQueryResult[passKey].toString();
+
+  return hashedPassword;
+};

--- a/server/src/middlewares/passport.js
+++ b/server/src/middlewares/passport.js
@@ -21,6 +21,7 @@ passport.use(
       try {
         user = await authService.localLogin({ id, password });
         delete user.password;
+        delete user.salt;
       } catch (err) {
         return done(err);
       }

--- a/server/src/v1/auth/service.js
+++ b/server/src/v1/auth/service.js
@@ -1,7 +1,7 @@
-import sequelize from 'sequelize';
 import DB from '../../database/index';
 import ERROR_CODE from '../../libraries/exception/error-code';
 import ErrorResponse from '../../libraries/exception/error-response';
+import { encrypt } from '../../libraries/crypto';
 
 const localLogin = async ({ id, password }) => {
   const user = await DB.User.findOneById(id);
@@ -10,12 +10,7 @@ const localLogin = async ({ id, password }) => {
     throw new ErrorResponse(ERROR_CODE.INVALID_LOGIN_ID_OR_PASSWORD);
   }
 
-  const [result] = await DB.sequelize.query(
-    `SELECT ENCRYPT('${password}', CONCAT('$6$', '${user.salt}'))`,
-    { raw: true, type: sequelize.QueryTypes.SELECT },
-  );
-  const [key] = Object.keys(result);
-  const hashedPassword = result[key].toString();
+  const hashedPassword = await encrypt(password, user.salt);
 
   const match = user.password === hashedPassword;
 

--- a/server/src/v1/auth/service.js
+++ b/server/src/v1/auth/service.js
@@ -1,6 +1,4 @@
-import bcrypt from 'bcrypt';
-import crypto from 'crypto';
-
+import sequelize from 'sequelize';
 import DB from '../../database/index';
 import ERROR_CODE from '../../libraries/exception/error-code';
 import ErrorResponse from '../../libraries/exception/error-response';
@@ -12,10 +10,13 @@ const localLogin = async ({ id, password }) => {
     throw new ErrorResponse(ERROR_CODE.INVALID_LOGIN_ID_OR_PASSWORD);
   }
 
-  const hashedPassword = crypto
-    .createHash('sha512')
-    .update(password)
-    .digest('base64');
+  const [result] = await DB.sequelize.query(
+    `SELECT ENCRYPT('${password}', CONCAT('$6$', '${user.salt}'))`,
+    { raw: true, type: sequelize.QueryTypes.SELECT },
+  );
+  const [key] = Object.keys(result);
+  const hashedPassword = result[key].toString();
+
   const match = user.password === hashedPassword;
 
   if (!match) {

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -24,6 +24,8 @@ const register = async ({ id, password, name, sub_email }) => {
   }
 
   delete newUser.password;
+  delete newUser.salt;
+
   return newUser;
 };
 

--- a/server/test/crypto.spec.js
+++ b/server/test/crypto.spec.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-undef */
+import should from 'should';
+import { createSalt, encrypt } from '../src/libraries/crypto';
+
+describe('crypto 모듈의', () => {
+  describe('createSalt() 호출시', () => {
+    it('string을 반환한다.', async () => {
+      const salt = await createSalt();
+      salt.should.be.type('string');
+    });
+
+    it('무작위한 값을 만들어낸다.', async () => {
+      const salt1 = await createSalt();
+      const salt2 = await createSalt();
+      const match = salt1 !== salt2;
+      match.should.be.equal(true);
+    });
+  });
+
+  describe('encrypt() 호출시', () => {
+    it('string을 반환한다.', async () => {
+      const encryption = await encrypt('hihi', 'hihi2');
+      encryption.should.be.type('string');
+    });
+
+    it('동일한 인자를 줄 경우 동일한 값을 반환한다.', async () => {
+      const encryption1 = await encrypt('hihi', 'hihi2');
+      const encryption2 = await encrypt('hihi', 'hihi2');
+      const match = encryption1 === encryption2;
+      match.should.be.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
### 무엇을 (What)
1. 회원가입시 암호화 알고리즘 변경
2. 회원가입시 암호화에 사용하는 Salt값을 함께 DB에 저장

### 왜 그 방법을 선택했는가? (Why)
1. Dovecot SASL 인증을 위한 암호화 방식 통일

### 리뷰어 참고사항
1. 메일 서버 DB의 user 추가시 비밀번호를 다음과 같은 형식으로 지정
`
ENCRYPT('password', CONCAT('$6$', SUBSTRING(SHA(RAND()), -16)))
`
2. query 결과값이 buffer라서 string형으로 바꿔주기 위하여 toString() 사용
3. MySQL Encryption and Compression Functions
https://dev.mysql.com/doc/refman/5.5/en/encryption-functions.html