### PR TITLE
[BE] 비밀번호 찾기 API 구현

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6243,6 +6243,11 @@
         "is-property": "^1.0.2"
       }
     },
+    "generate-password": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/generate-password/-/generate-password-1.4.2.tgz",
+      "integrity": "sha512-UYEOMRcnpC/228qfCQNSebq8jmIonoPYPILsZl2NmH16Vm53yPvgo/KK3BYeCA3JmhSA/a/HqHzaY0v5dRbyoQ=="
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -94,6 +94,7 @@
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
+    "generate-password": "^1.4.2",
     "helmet": "^3.21.1",
     "http-status": "^1.4.1",
     "multer": "^1.4.2",

--- a/server/src/database/models/user.js
+++ b/server/src/database/models/user.js
@@ -123,11 +123,11 @@ const model = (sequelize, DataTypes) => {
     });
   };
 
-  User.findOneByIdAndEmail = (id, email) => {
+  User.findOneByIdAndSubEmail = (id, sub_email) => {
     return User.findOne({
       where: {
         id,
-        sub_email: email,
+        sub_email,
       },
     });
   };

--- a/server/src/database/models/user.js
+++ b/server/src/database/models/user.js
@@ -123,6 +123,15 @@ const model = (sequelize, DataTypes) => {
     });
   };
 
+  User.findOneByIdAndEmail = (id, email) => {
+    return User.findOne({
+      where: {
+        id,
+        sub_email: email,
+      },
+    });
+  };
+
   User.beforeBulkCreate(async instances => {
     for (const instance of instances) {
       await convertToUserModel(instance);

--- a/server/src/libraries/exception/error-code.js
+++ b/server/src/libraries/exception/error-code.js
@@ -32,6 +32,11 @@ const ERROR_CODE = {
     'LOGIN001',
   ),
   EMAIL_NOT_FOUND: $(404, '가입된 적 없는 이메일 입니다.', 'COMMON009'),
+  LOGIN_ID_OR_EMAIL_NOT_FOUND: $(
+    404,
+    '가입하지 않은 아이디이거나, 가입에 사용하지 않은 이메일 입니다.',
+    'COMMON010',
+  ),
   ID_DUPLICATION: $(409, '이미 사용중인 아이디 입니다.', 'JOIN001'),
   EMAIL_DUPLICATION: $(409, '이미 가입에 사용한 이메일 입니다.', 'JOIN002'),
 

--- a/server/src/libraries/generator.js
+++ b/server/src/libraries/generator.js
@@ -1,0 +1,9 @@
+export const createRandStr = (length = 8) => {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+  return result;
+};

--- a/server/src/libraries/mail-util.js
+++ b/server/src/libraries/mail-util.js
@@ -48,6 +48,23 @@ const createMailTemplateToFindId = id => {
     </p><span style="font-style: italic;">Copyright ⓒ Daitnu Corp. All Rights Reserved.</span>`;
 };
 
+const createMailTemplateToFindPassword = password => {
+  return `
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+KR&display=swap" rel="stylesheet">
+    <h1 style="font-family: 'Noto Sans KR', sans-serif;">임시 비밀번호를</h1>
+    <h1 style="color: #3742fa; font-family: 'Noto Sans KR', sans-serif;">알려드립니다.</h1>
+    <img src="https://user-images.githubusercontent.com/33617083/68571001-457a9d80-04a5-11ea-9a47-98c0fd36a1d9.png"/>
+    <p style="font-family: 'Noto Sans KR', sans-serif;"><span style="font-size: 20px; margin-left: 5px; font-weight: bold">임시 비밀번호: </span>
+    <span style="color: #3742fa; font-size: 20px; font-weight: bold;">${password}</span></p>
+    <br>
+    <p style="font-size: 16px; font-family: 'Noto Sans KR', sans-serif;">
+
+    Daitnu를 이용해 주셔서 감사합니다.<br>
+    더욱 편리한 서비스를 제공하기 위해 항상 최선을 다하겠습니다.<br>
+    </p>
+    </p><span style="font-style: italic;">Copyright ⓒ Daitnu Corp. All Rights Reserved.</span>`;
+};
+
 const sendMail = data => {
   const transport = getTransport();
   const transporter = nodemailer.createTransport(transport);
@@ -71,8 +88,20 @@ const sendMailToFindId = ({ id, email }) => {
   sendMail(mailData);
 };
 
+const sendMailToFindPassword = ({ id, password, email }) => {
+  const mailData = {
+    from: '"Daitnu" root@daitnu.com',
+    to: email,
+    subject: '[Daitnu] 임시 비밀번호를 알려드립니다.',
+    html: createMailTemplateToFindPassword(password),
+  };
+
+  sendMail(mailData);
+};
+
 export default {
   getSingleMailData,
   getTransport,
   sendMailToFindId,
+  sendMailToFindPassword,
 };

--- a/server/src/libraries/mail-util.js
+++ b/server/src/libraries/mail-util.js
@@ -79,7 +79,7 @@ const sendMailToFindId = ({ id, email }) => {
   id = replace.hideIdUseAsterisk(id, hideStartIndex, hideEndIndex);
 
   const mailData = {
-    from: '"Daitnu" root@daitnu.com',
+    from: '"Daitnu" no-reply@daitnu.com',
     to: email,
     subject: '[Daitnu] 요청하신 아이디를 알려드립니다.',
     html: createMailTemplateToFindId(id),
@@ -90,7 +90,7 @@ const sendMailToFindId = ({ id, email }) => {
 
 const sendMailToFindPassword = ({ password, email }) => {
   const mailData = {
-    from: '"Daitnu" root@daitnu.com',
+    from: '"Daitnu" no-reply@daitnu.com',
     to: email,
     subject: '[Daitnu] 임시 비밀번호를 알려드립니다.',
     html: createMailTemplateToFindPassword(password),

--- a/server/src/libraries/mail-util.js
+++ b/server/src/libraries/mail-util.js
@@ -88,7 +88,7 @@ const sendMailToFindId = ({ id, email }) => {
   sendMail(mailData);
 };
 
-const sendMailToFindPassword = ({ id, password, email }) => {
+const sendMailToFindPassword = ({ password, email }) => {
   const mailData = {
     from: '"Daitnu" root@daitnu.com',
     to: email,

--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -48,7 +48,7 @@ const checkBodyForPasswordSearch = ({ id, email }) => {
   const errorFields = [];
 
   if (!id || !validate('id', id)) {
-    const errorField = new ErrorField('email', email, 'id 값이 올바르지 않습니다.');
+    const errorField = new ErrorField('id', id, 'id 값이 올바르지 않습니다.');
     errorFields.push(errorField);
   }
 

--- a/server/src/libraries/validation/user.js
+++ b/server/src/libraries/validation/user.js
@@ -44,4 +44,24 @@ const checkBodyForIdSearch = ({ email }) => {
   return true;
 };
 
-export default { join, checkQueryForSearch, checkBodyForIdSearch };
+const checkBodyForPasswordSearch = ({ id, email }) => {
+  const errorFields = [];
+
+  if (!id || !validate('id', id)) {
+    const errorField = new ErrorField('email', email, 'id 값이 올바르지 않습니다.');
+    errorFields.push(errorField);
+  }
+
+  if (!email || !validate('email', email)) {
+    const errorField = new ErrorField('email', email, 'email 값이 올바르지 않습니다.');
+    errorFields.push(errorField);
+  }
+
+  if (errorFields.length > 0) {
+    throw new ErrorResponse(ERROR_CODE.INVALID_INPUT_VALUE, errorFields);
+  }
+
+  return true;
+};
+
+export default { join, checkQueryForSearch, checkBodyForIdSearch, checkBodyForPasswordSearch };

--- a/server/src/v1/users/controller.js
+++ b/server/src/v1/users/controller.js
@@ -16,22 +16,17 @@ const registerUser = async (req, res, next) => {
 };
 
 const search = async (req, res, next) => {
+  const { type } = req.query;
+  const { id, email } = req.body;
+
   try {
     validation.checkQueryForSearch(req.query);
-
-    switch (req.query.type) {
-      case 'id': {
-        validation.checkBodyForIdSearch(req.body);
-        await service.sendUserIdToEmail(req.body.email);
-        break;
-      }
-      case 'pw':
-        validation.checkBodyForPasswordSearch(req.body);
-        await service.sendUserPasswordToEmail(req.body.id, req.body.email);
-        break;
-
-      default:
-        break;
+    if (type === 'id') {
+      validation.checkBodyForIdSearch(req.body);
+      await service.sendUserIdToEmail(email);
+    } else if (type === 'pw') {
+      validation.checkBodyForPasswordSearch(req.body);
+      await service.sendUserPasswordToEmail(id, email);
     }
   } catch (err) {
     return next(err);

--- a/server/src/v1/users/controller.js
+++ b/server/src/v1/users/controller.js
@@ -26,6 +26,8 @@ const search = async (req, res, next) => {
         break;
       }
       case 'pw':
+        validation.checkBodyForPasswordSearch(req.body);
+        await service.sendUserPasswordToEmail(req.body.id, req.body.email);
         break;
 
       default:

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -1,12 +1,13 @@
+import generator from 'generate-password';
+
 import DB from '../../database';
 import ErrorResponse from '../../libraries/exception/error-response';
 import ERROR_CODE from '../../libraries/exception/error-code';
 import mailUtil from '../../libraries/mail-util';
-import { createSalt, encrypt } from '../../libraries/crypto';
-import { createRandStr } from '../../libraries/generator';
+import { encrypt } from '../../libraries/crypto';
 
 const DEFAULT_CATEGORIES = ['전체메일함', '받은메일함', '보낸메일함', '내게쓴메일함', '휴지통'];
-const TEMP_PASSWORD_LENGTH = 8;
+const TEMP_PASSWORD_LENGTH = 15;
 
 // eslint-disable-next-line camelcase
 const register = async ({ id, password, name, sub_email }) => {
@@ -59,7 +60,11 @@ const sendUserPasswordToEmail = async (id, email) => {
     throw new ErrorResponse(ERROR_CODE.LOGIN_ID_OR_EMAIL_NOT_FOUND);
   }
 
-  const newPassword = createRandStr(TEMP_PASSWORD_LENGTH);
+  const newPassword = generator.generate({
+    length: TEMP_PASSWORD_LENGTH,
+    numbers: true,
+  });
+
   const hashedPassword = await encrypt(newPassword, user.salt);
 
   user.password = hashedPassword;

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -55,7 +55,7 @@ const sendUserIdToEmail = async email => {
 };
 
 const sendUserPasswordToEmail = async (id, email) => {
-  const user = await DB.User.findOneByIdAndEmail(id, email);
+  const user = await DB.User.findOneByIdAndSubEmail(id, email);
   if (!user) {
     throw new ErrorResponse(ERROR_CODE.LOGIN_ID_OR_EMAIL_NOT_FOUND);
   }

--- a/server/test/generator.spec.js
+++ b/server/test/generator.spec.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-undef */
+import should from 'should';
+import { createRandStr } from '../src/libraries/generator';
+
+describe('generator 모듈의', () => {
+  describe('createRandStr() 호출시', () => {
+    it('length를 인자로 넘겨줄 경우 길이가 length인 string을 반환한다.', async () => {
+      const length = 12;
+      const randStr = await createRandStr(length);
+      randStr.should.be.type('string');
+      randStr.length.should.be.equal(length);
+    });
+
+    it('아무 인자도 넘겨주지 않을 경우 길이가 8인 string을 반환한다.', async () => {
+      const randStr = await createRandStr();
+      randStr.should.be.type('string');
+      randStr.length.should.be.equal(8);
+    });
+
+    it('무작위한 값을 만들어낸다.', async () => {
+      const length = 12;
+      const randStr1 = await createRandStr(length);
+      const randStr2 = await createRandStr(length);
+      const match = randStr1 !== randStr2;
+      match.should.be.equal(true);
+    });
+  });
+});

--- a/server/test/user/api.spec.js
+++ b/server/test/user/api.spec.js
@@ -265,4 +265,54 @@ describe('POST /users/search는...', () => {
       .send({ email: 'daitnu@daitnu22.com' })
       .expect(404, done);
   });
+
+  it('# 비밀번호를 찾을 때 가입에 사용하지 않은 메일을 넘겨줄 경우 상태코드는 404이다.', done => {
+    request(app)
+      .post('/v1/users/search?type=pw')
+      .send({ id: user1.id, email: 'daitnu@daitnu22.com' })
+      .expect(404, done);
+  });
+
+  it('# 비밀번호를 찾을 때 가입을 하지 않은 아이디를 넘겨줄 경우 상태코드는 404이다.', done => {
+    request(app)
+      .post('/v1/users/search?type=pw')
+      .send({ id: 'hahoho', email: user1.sub_email })
+      .expect(404, done);
+  });
+
+  it('# type이 pw이고 body로 email을 주지 않을 경우 상태코드는 400이다.', done => {
+    request(app)
+      .post('/v1/users/search?type=pw')
+      .send({ id: 'hihihi' })
+      .expect(400, done);
+  });
+
+  it('# type이 pw이고 body로 id를 주지 않을 경우 상태코드는 400이다.', done => {
+    request(app)
+      .post('/v1/users/search?type=pw')
+      .send({ email: 'test@test.com' })
+      .expect(400, done);
+  });
+
+  it('# 비밀번호 찾을 때 body로 email을 주지 않을 경우 실패한다.', done => {
+    request(app)
+      .post('/v1/users/search?type=pw')
+      .send({ id: 'hihihi' })
+      .end((err, { body }) => {
+        const { fieldErrors } = body;
+        fieldErrors[0].should.be.properties({ field: 'email' });
+        done();
+      });
+  });
+
+  it('# 비밀번호 찾을 때 body로 id를 주지 않을 경우 실패한다.', done => {
+    request(app)
+      .post('/v1/users/search?type=pw')
+      .send({ email: 'test@test.com' })
+      .end((err, { body }) => {
+        const { fieldErrors } = body;
+        fieldErrors[0].should.be.properties({ field: 'id' });
+        done();
+      });
+  });
 });

--- a/server/test/user/service.spec.js
+++ b/server/test/user/service.spec.js
@@ -100,4 +100,40 @@ describe('user service는...', () => {
       }
     });
   });
+
+  describe('sendUserPasswordToEmail 함수는...', () => {
+    it('# 가입에 사용되지 않은 이메일일 경우 ErrorResponse instance를 반환한다.', async () => {
+      try {
+        await service.sendUserPasswordToEmail(user.id, 'abcabc@zzz.zzz');
+      } catch (error) {
+        error.should.be.instanceOf(ErrorResponse);
+      }
+    });
+
+    it('# 가입에 사용되지 않은 이메일일 경우 ERROR_CODE는 LOGIN_ID_OR_EMAIL_NOT_FOUND이다.', async () => {
+      try {
+        await service.sendUserPasswordToEmail(user.id, 'abcabc@zzz.zzz');
+      } catch (error) {
+        const { errorCode } = error;
+        errorCode.should.be.eql(ERROR_CODE.LOGIN_ID_OR_EMAIL_NOT_FOUND);
+      }
+    });
+
+    it('# 가입하지 않은 아이디일 경우 ErrorResponse instance를 반환한다.', async () => {
+      try {
+        await service.sendUserPasswordToEmail('kkzzzk', user.sub_email);
+      } catch (error) {
+        error.should.be.instanceOf(ErrorResponse);
+      }
+    });
+
+    it('# 가입하지 않은 아이디일 경우 ERROR_CODE는 LOGIN_ID_OR_EMAIL_NOT_FOUND이다.', async () => {
+      try {
+        await service.sendUserPasswordToEmail('kkzzzk', user.sub_email);
+      } catch (error) {
+        const { errorCode } = error;
+        errorCode.should.be.eql(ERROR_CODE.LOGIN_ID_OR_EMAIL_NOT_FOUND);
+      }
+    });
+  });
 });

--- a/server/test/validator.spec.js
+++ b/server/test/validator.spec.js
@@ -41,6 +41,7 @@ describe('validator 모듈의', () => {
       validate('email', 'abcde@daitne..com').should.be.equal(false);
       validate('email', 'a@a.m').should.be.equal(false);
       validate('email', 'abcdef@abcdef').should.be.equal(false);
+      validate('email', 'eoiwjw@aspd').should.be.equal(false);
     });
   });
 


### PR DESCRIPTION
### 무엇을 (What)
1. 비밀번호 찾기 API 구현 (임시비밀번호를 생성하여 메일로 보내줌)
2. generator 모듈의 무작위 문자열을 생성하는 createRandStr 함수 구현
3. 임시비밀번호 생성시 createRandStr 함수를 사용

### 왜 그 방법을 선택했는가? (Why)
1. 보통 비밀번호를 찾을 때 임시비밀번호를 메일로 보내줌
2. createSalt 같은 경우 DB에 쿼리를 보내는 방식으로 무작위 문자열을 생성하여 비효율적이라서 새로운 무작위 문자열 생성 함수 구현

### 리뷰어 참고사항
1. 임시 비밀번호를 메일로 보내기 위해서 `.env` 파일에 메일 계정을 설정해야함. 
   회원가입 페이지를 통해 회원정보를 DB에 등록하고 설정해도 됨
```bash
# user table의 email 필드
MAIL_AUTH_USER=

# 회원가입할때 입력한 비밀번호
MAIL_AUTH_PASS=
```
