### PR TITLE
전역 context의 state에 view 추가

### DIFF
--- a/web/components/Aside/index.js
+++ b/web/components/Aside/index.js
@@ -11,7 +11,7 @@ import S from './styled';
 import MailArea from '../MailArea';
 import WriteMail from '../WriteMail';
 import { AppContext } from '../../contexts';
-import { handleCategoryClick } from '../../contexts/reducer';
+import { handleCategoryClick, setView } from '../../contexts/reducer';
 
 const useStyles = makeStyles(theme => ({
   nested: {
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const Aside = ({ setView }) => {
+const Aside = () => {
   const classes = useStyles();
   const [open, setOpen] = React.useState(true);
   const { state, dispatch } = useContext(AppContext);
@@ -29,20 +29,23 @@ const Aside = ({ setView }) => {
   };
 
   const defaultCategory = [
-    { name: '받은편지함', icon: <AllInboxIcon />, view: <MailArea />, category: 0 },
-    { name: '중요편지함', icon: <StarBorder />, view: <></>, category: 1 },
-    { name: '보낸메일함', icon: <SendIcon />, view: <></>, category: 2 },
-    { name: '내게쓴메일함', icon: <DraftsIcon />, view: <></>, category: 3 },
-    { name: '휴지통', icon: <DeleteIcon />, view: <></>, category: 4 },
+    { name: '받은편지함', icon: <AllInboxIcon />, no: 0 },
+    { name: '중요편지함', icon: <StarBorder />, no: 1 },
+    { name: '보낸메일함', icon: <SendIcon />, no: 2 },
+    { name: '내게쓴메일함', icon: <DraftsIcon />, no: 3 },
+    { name: '휴지통', icon: <DeleteIcon />, no: 4 },
   ];
 
   const userCategory = [
-    { name: '대햇', icon: <StarBorder />, view: <></> },
-    { name: '흑우', icon: <StarBorder />, view: <></> },
+    { name: '대햇', icon: <StarBorder />, no: 5 },
+    { name: '흑우', icon: <StarBorder />, no: 6 },
   ];
 
   const defaultCard = defaultCategory.map((category, idx) => (
-    <ListItem button key={idx} onClick={() => dispatch(handleCategoryClick(category.category))}>
+    <ListItem
+      button
+      key={idx}
+      onClick={() => dispatch(handleCategoryClick(category, <MailArea />))}>
       <ListItemIcon>{category.icon}</ListItemIcon>
       <ListItemText primary={category.name} />
     </ListItem>
@@ -58,7 +61,7 @@ const Aside = ({ setView }) => {
     <S.Aside>
       <List component="nav">
         <ListItem>
-          <S.WrtieButton onClick={e => setView(<WriteMail />)}>편지쓰기</S.WrtieButton>
+          <S.WrtieButton onClick={() => dispatch(setView(<WriteMail />))}>편지쓰기</S.WrtieButton>
           <S.WrtieButton>내게쓰기</S.WrtieButton>
         </ListItem>
         {defaultCard}

--- a/web/components/Header/index.js
+++ b/web/components/Header/index.js
@@ -3,11 +3,12 @@ import React, { useContext } from 'react';
 import * as S from './styled';
 import LogoutButton from '../LogoutButton';
 import { AppContext } from '../../contexts';
-import { setSelected } from '../../contexts/reducer';
+import { setView } from '../../contexts/reducer';
+import MailArea from '../MailArea';
 
 const Header = ({ brand }) => {
   const { dispatch } = useContext(AppContext);
-  const handleAtagClick = () => dispatch(setSelected(null));
+  const handleAtagClick = () => dispatch(setView(<MailArea />));
   return (
     <S.Header>
       <S.Brand>

--- a/web/components/MailTemplate/index.js
+++ b/web/components/MailTemplate/index.js
@@ -3,13 +3,14 @@ import React, { useContext } from 'react';
 import moment from 'moment';
 import * as S from './styled';
 import { AppContext } from '../../contexts';
-import { setSelected } from '../../contexts/reducer';
+import { handleMailClick } from '../../contexts/reducer';
+import ReadMail from '../ReadMail';
 
 const MailTemplate = ({ mail, no }) => {
-  const { state, dispatch } = useContext(AppContext);
+  const { dispatch } = useContext(AppContext);
   const { from, subject, date, is_important, is_read } = mail;
   const startdate = moment(date).format('YYYY-MM-DD');
-  const handleSubjectClick = () => dispatch(setSelected(mail, no));
+  const handleSubjectClick = () => dispatch(handleMailClick(mail, <ReadMail />));
   return (
     <S.MailTemplateWrap>
       <div>

--- a/web/components/ReadMail/PageMoveButtonArea/index.js
+++ b/web/components/ReadMail/PageMoveButtonArea/index.js
@@ -4,22 +4,16 @@ import IconButton from '@material-ui/core/IconButton';
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import { AppContext } from '../../../contexts';
-import { setSelected } from '../../../contexts/reducer';
 
 const PageMoveButtonArea = () => {
   const { state, dispatch } = useContext(AppContext);
-  const { mails, selected } = state;
-  const handlePrevClick = () =>
-    dispatch(setSelected(mails[selected.no - 1].MailTemplate, selected.no - 1));
-  const handleNextClick = () =>
-    dispatch(setSelected(mails[selected.no + 1].MailTemplate, selected.no + 1));
 
   return (
     <S.Container>
-      <IconButton disabled={selected.no < 1} onClick={handlePrevClick}>
+      <IconButton>
         <ArrowBackIosIcon />
       </IconButton>
-      <IconButton disabled={selected.no === mails.length - 1} onClick={handleNextClick}>
+      <IconButton>
         <ArrowForwardIosIcon />
       </IconButton>
     </S.Container>

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import * as S from './styled';
 import PageMoveButtonArea from './PageMoveButtonArea';
 import { StarBorder } from '@material-ui/icons';
+import { AppContext } from '../../contexts';
 
-const ReadMail = ({ mail }) => {
-  const { to, from, subject, createdAt, text } = mail;
+const ReadMail = () => {
+  const { state } = useContext(AppContext);
+  const { to, from, subject, createdAt, text } = state.mail;
   const receivers = to.replace(',', ', ');
 
   return (

--- a/web/contexts/reducer.js
+++ b/web/contexts/reducer.js
@@ -1,31 +1,33 @@
+const CATEGORY_CLICK = 'CATEGORY_CLICK';
+const PAGE_NUMBER_CLICK = 'PAGE_NUMBER_CLICK';
+const CHANGE_MAILS_DATA = 'CHANGE_MAILS_DATA';
+const MAIL_CLICK = 'MAIL_CLICK';
+const SET_VIEW = 'SET_VIEW';
+
 export const initialState = {
   category: 0,
   page: 1,
   mails: null,
-  selected: { mail: null, no: 0 },
   paging: null,
+  view: null,
 };
 
-const CATEGORY_CLICK = 'CATEGORY_CLICK';
-const PAGE_NUMBER_CLICK = 'PAGE_NUMBER_CLICK';
-const SET_CURRENT_MAIL = 'SET_CURRENT_MAIL';
-const CHANGE_MAILS_DATA = 'CHANGE_MAILS_DATA';
-
-export const handleCategoryClick = category => {
+export const handleCategoryClick = (category, view) => {
   return {
     type: CATEGORY_CLICK,
     payload: {
-      category,
+      category: category.no,
       page: 1,
-      selected: { mail: null, no: 0 },
+      view,
     },
   };
 };
 
-export const handleMailsChange = ({ mails, paging }) => {
+export const handleMailsChange = ({ category, mails, paging }) => {
   return {
     type: CHANGE_MAILS_DATA,
     payload: {
+      category,
       mails,
       paging,
     },
@@ -41,11 +43,21 @@ export const handlePageNumberClick = page => {
   };
 };
 
-export const setSelected = (mail, no) => {
+export const handleMailClick = (mail, view) => {
   return {
-    type: SET_CURRENT_MAIL,
+    type: MAIL_CLICK,
     payload: {
-      selected: { mail, no },
+      mail,
+      view,
+    },
+  };
+};
+
+export const setView = view => {
+  return {
+    type: SET_VIEW,
+    payload: {
+      view,
     },
   };
 };
@@ -57,9 +69,11 @@ export const reducer = (state = initialState, action) => {
       return { ...state, ...payload };
     case PAGE_NUMBER_CLICK:
       return { ...state, ...payload };
-    case SET_CURRENT_MAIL:
+    case MAIL_CLICK:
       return { ...state, ...payload };
     case CHANGE_MAILS_DATA:
+      return { ...state, ...payload };
+    case SET_VIEW:
       return { ...state, ...payload };
     default:
       return { ...state };

--- a/web/pages/index.js
+++ b/web/pages/index.js
@@ -6,13 +6,12 @@ import MailArea from '../components/MailArea';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import Loading from '../components/Loading';
-import ReadMail from '../components/ReadMail';
 import { AppContext } from '../contexts';
+import { setView } from '../contexts/reducer';
 
 const Home = () => {
-  const { state } = useContext(AppContext);
+  const { state, dispatch } = useContext(AppContext);
   const [user, setUser] = useState(null);
-  const [view, setView] = useState(null);
 
   useEffect(() => {
     if (!window.sessionStorage.getItem('user')) {
@@ -20,7 +19,7 @@ const Home = () => {
     } else {
       const userData = window.sessionStorage.getItem('user');
       setUser(JSON.parse(userData));
-      setView(<MailArea />);
+      dispatch(setView(<MailArea />));
     }
   }, []);
 
@@ -28,8 +27,8 @@ const Home = () => {
     <GS.FlexWrap>
       <Header brand={'Daitnu'} />
       <GS.Content>
-        <Aside setView={setView} />
-        {state.selected.mail ? <ReadMail mail={state.selected.mail} /> : view}
+        <Aside />
+        {state.view}
       </GS.Content>
       <Footer />
     </GS.FlexWrap>


### PR DESCRIPTION
### 무엇을 (What)
1. 기존에 context의 state에 있던 selected를 제거하고 view를 추가하여 view의 상태관리를 통해 메일리스트, 메일읽기, 메일쓰기 화면 전환이 가능하도록 변경

### 왜 그 방법을 선택했는가? (Why)
1. selected는 메일리스트 <-> 메일읽기 화면 전환만 고려하였기 때문에 메일 쓰기에서 메일 보관함 클릭 시 화면 회전이 되지않았음. 이를 수정하기 위해 selected 삭제하고 view를 추가

### 리뷰어 참고사항
돌아가는거에 집중하여 수정했으므로 부족한 부분이 있을 수 있음
