### PR TITLE
[FE] 다른 카테고리에서 전체메일함 이동 오류 수정 / 메일읽기 상단 툴바 외형만 구현

### DIFF
--- a/web/components/Header/index.js
+++ b/web/components/Header/index.js
@@ -4,12 +4,12 @@ import * as S from './styled';
 
 import ProfileLink from '../ProfileLink';
 import { AppDisapthContext } from '../../contexts';
-import { setView } from '../../contexts/reducer';
+import { handleCategoryClick } from '../../contexts/reducer';
 import MailArea from '../MailArea';
 
 const Header = ({ brand }) => {
   const { dispatch } = useContext(AppDisapthContext);
-  const handleAtagClick = () => dispatch(setView(<MailArea />));
+  const handleAtagClick = () => dispatch(handleCategoryClick(0, <MailArea />));
   return (
     <S.Header>
       <S.Brand>

--- a/web/components/ReadMail/PageMoveButtonArea/styled.js
+++ b/web/components/ReadMail/PageMoveButtonArea/styled.js
@@ -4,7 +4,8 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 60px;
+  border-top: 2px solid #e9ecef;
+  height: 50px;
 `;
 
 export { Container };

--- a/web/components/ReadMail/ToolGroup/index.js
+++ b/web/components/ReadMail/ToolGroup/index.js
@@ -1,8 +1,15 @@
 import React, { useContext } from 'react';
 import * as S from './styled';
 
+const buttonNames = ['답장', '전체답장', '전달', '삭제'];
+const buttonSet = buttonNames.map(name => <button>{name}</button>);
+
 const ToolGroup = () => {
-  return <S.Container></S.Container>;
+  return (
+    <S.Container>
+      <S.ButtonSet>{buttonSet}</S.ButtonSet>
+    </S.Container>
+  );
 };
 
 export default ToolGroup;

--- a/web/components/ReadMail/ToolGroup/index.js
+++ b/web/components/ReadMail/ToolGroup/index.js
@@ -1,0 +1,8 @@
+import React, { useContext } from 'react';
+import * as S from './styled';
+
+const ToolGroup = () => {
+  return <S.Container></S.Container>;
+};
+
+export default ToolGroup;

--- a/web/components/ReadMail/ToolGroup/styled.js
+++ b/web/components/ReadMail/ToolGroup/styled.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  flex: 0 0 50px;
+  border-bottom: 2px solid #e9ecef;
+  display: flex;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+`;
+
+export { Container };

--- a/web/components/ReadMail/ToolGroup/styled.js
+++ b/web/components/ReadMail/ToolGroup/styled.js
@@ -5,8 +5,28 @@ const Container = styled.div`
   border-bottom: 2px solid #e9ecef;
   display: flex;
   text-align: center;
-  justify-content: center;
   align-items: center;
+  padding: 0 20px;
 `;
 
-export { Container };
+const ButtonSet = styled.div`
+  button + button {
+    border-left: none;
+  }
+
+  button {
+    height: 28px;
+    padding: 0 9px;
+    border: 2px solid #cbcbcb;
+    background-color: #f8f8f8;
+    color: #333;
+    font: 700 14px Arial;
+    cursor: pointer;
+  }
+
+  button:hover {
+    background-color: #cbcbcb;
+  }
+`;
+
+export { Container, ButtonSet };

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -4,6 +4,7 @@ import * as S from './styled';
 import PageMoveButtonArea from './PageMoveButtonArea';
 import { AppStateContext } from '../../contexts';
 import moment from 'moment';
+import ToolGroup from './ToolGroup';
 
 const ReadMail = () => {
   const { state } = useContext(AppStateContext);
@@ -15,7 +16,7 @@ const ReadMail = () => {
 
   return (
     <S.Container>
-      <S.Tools>Tools</S.Tools>
+      <ToolGroup />
       <S.ReadArea>
         <S.TitleView>
           <S.Subject>


### PR DESCRIPTION
### 무엇을 (What)
1. 다른 카테고리에서 Header 클릭 시 전체메일함 이동 오류 수정
2. 메일읽기 상단 툴바 외형만 구현

### 왜 그 방법을 선택했는가? (Why)
1. 단순하게 setView -> handleCategoryClick으로 변경
2. 추후 업데이트 될 예정 일단 메일 삭제 구현해야됨

### 리뷰어 참고사항
header클릭이 category 클릭이 아니지만 전체메일함 카테고리 클릭과 같은 효과이므로 재활용

