### PR TITLE
[FE] 회원가입 후 메시지 표시

### DIFF
--- a/web/components/Forms/FindIdForm/index.js
+++ b/web/components/Forms/FindIdForm/index.js
@@ -10,10 +10,6 @@ import { errorParser } from '../../../utils/error-parser';
 import S from './styled';
 
 const useStyles = makeStyles(theme => ({
-  container: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
   textField: {
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),

--- a/web/components/Forms/FindPwForm/index.js
+++ b/web/components/Forms/FindPwForm/index.js
@@ -10,10 +10,6 @@ import { errorParser } from '../../../utils/error-parser';
 import S from './styled';
 
 const useStyles = makeStyles(theme => ({
-  container: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
   textField: {
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),

--- a/web/components/Forms/LoginForm/index.js
+++ b/web/components/Forms/LoginForm/index.js
@@ -72,6 +72,7 @@ const LoignForm = () => {
         name="userId"
         maxLength={20}
         ref={register}
+        autoComplete="off"
       />
       <S.ErrorText>{errors.userId && errors.userId.message}</S.ErrorText>
       <S.Input
@@ -82,6 +83,7 @@ const LoignForm = () => {
         name="password"
         maxLength={20}
         ref={register}
+        autoComplete="off"
       />
       <S.ErrorText>
         {(errors.password && errors.password.message) || (errors.login && errors.login.message)}

--- a/web/components/Forms/LoginForm/index.js
+++ b/web/components/Forms/LoginForm/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import Router from 'next/router';
 import useForm from 'react-hook-form';
 
@@ -12,9 +12,20 @@ import validator from '../../../utils/validator';
 import S from './styled';
 import storage from '../../../utils/storage';
 import request from '../../../utils/request';
+import { setMessage } from '../../../contexts/reducer';
+import { AppDisapthContext } from '../../../contexts';
 
 const LoignForm = () => {
   const { register, handleSubmit, errors, setError, clearError } = useForm();
+  const { dispatch } = useContext(AppDisapthContext);
+
+  const handleRouteChange = url => {
+    if (url !== '/login') {
+      dispatch(setMessage(''));
+    }
+  };
+
+  Router.events.on('routeChangeStart', handleRouteChange);
 
   const onSubmit = (data, e) => {
     const { userId, password } = data;

--- a/web/components/Forms/PwChangeForm/index.js
+++ b/web/components/Forms/PwChangeForm/index.js
@@ -73,7 +73,7 @@ const PasswordModal = () => {
     }
   };
 
-  const onSubmitHandler = e => {
+  const handleSubmit = e => {
     e.preventDefault();
 
     if (validateForm()) {
@@ -101,7 +101,7 @@ const PasswordModal = () => {
       </S.InputContainer>
       <S.InputContainer>
         <TextField
-          id="passwrd"
+          id="password"
           label="비밀번호 입력"
           type="password"
           onChange={handleInputChange('password')}
@@ -133,7 +133,7 @@ const PasswordModal = () => {
         <S.WhiteButton className="submit-btn max-width" onClick={() => router.back()}>
           취소
         </S.WhiteButton>
-        <S.Button className="submit-btn max-width" onClick={onSubmitHandler}>
+        <S.Button className="submit-btn max-width" onClick={handleSubmit}>
           확인
         </S.Button>
       </S.ButtonContainer>

--- a/web/components/Forms/PwChangeForm/index.js
+++ b/web/components/Forms/PwChangeForm/index.js
@@ -23,17 +23,6 @@ const useStyles = makeStyles(theme => ({
     marginRight: theme.spacing(1),
     width: '100%',
   },
-  modal: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  paper: {
-    backgroundColor: theme.palette.background.paper,
-    border: '2px solid #000',
-    boxShadow: theme.shadows[5],
-    padding: theme.spacing(2, 4, 3),
-  },
 }));
 
 const initialInputState = {

--- a/web/components/Forms/PwChangeForm/index.js
+++ b/web/components/Forms/PwChangeForm/index.js
@@ -101,7 +101,7 @@ const PasswordModal = () => {
       </S.InputContainer>
       <S.InputContainer>
         <TextField
-          id="standard-basic"
+          id="passwrd"
           label="비밀번호 입력"
           type="password"
           onChange={handleInputChange('password')}
@@ -116,7 +116,7 @@ const PasswordModal = () => {
       </S.InputContainer>
       <S.InputContainer>
         <TextField
-          id="standard-basic"
+          id="checkPassword"
           label="비밀번호 재입력"
           type="password"
           onChange={handleInputChange('checkPassword')}

--- a/web/components/Forms/PwChangeForm/index.js
+++ b/web/components/Forms/PwChangeForm/index.js
@@ -61,6 +61,11 @@ const PasswordModal = () => {
     router.back();
   };
 
+  const handleCancle = e => {
+    e.preventDefault();
+    router.back();
+  };
+
   const updatePassword = async () => {
     try {
       const { password } = values;
@@ -130,7 +135,7 @@ const PasswordModal = () => {
         <S.ErrorText>{errors.checkPassword || errors.change}</S.ErrorText>
       </S.InputContainer>
       <S.ButtonContainer>
-        <S.WhiteButton className="submit-btn max-width" onClick={() => router.back()}>
+        <S.WhiteButton className="submit-btn max-width" onClick={handleCancle}>
           취소
         </S.WhiteButton>
         <S.Button className="submit-btn max-width" onClick={handleSubmit}>

--- a/web/components/Forms/PwChangeForm/styled.js
+++ b/web/components/Forms/PwChangeForm/styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const InputForm = styled.div`
+const InputForm = styled.form`
   width: 300px;
   display: flex;
   flex-direction: column;

--- a/web/components/Forms/RegisterForm/index.js
+++ b/web/components/Forms/RegisterForm/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Router from 'next/router';
 import { TextField, OutlinedInput, InputAdornment, IconButton } from '@material-ui/core';
 import { Visibility, VisibilityOff } from '@material-ui/icons';
@@ -10,6 +10,8 @@ import { ERROR_DIFFERENT_PASSWORD } from '../../../utils/error-message';
 import { SUCCESS_REGISTER } from '../../../utils/success-message';
 import S from './styled';
 import request from '../../../utils/request';
+import { setMessage } from '../../../contexts/reducer';
+import { AppDisapthContext } from '../../../contexts';
 
 const useStyles = makeStyles(theme => ({
   textField: {
@@ -39,6 +41,7 @@ const initialErrorState = {
 
 const RegisterForm = () => {
   const classes = useStyles();
+  const { dispatch } = useContext(AppDisapthContext);
 
   const [values, setValues] = useState(initialInputState);
   const [errors, setErrorMsg] = useState(initialErrorState);
@@ -64,7 +67,8 @@ const RegisterForm = () => {
       handleRegisterErrMsg(message);
       return;
     }
-    Router.push({ pathname: '/login', query: { message: SUCCESS_REGISTER } });
+    dispatch(setMessage(SUCCESS_REGISTER));
+    Router.push('/login');
   };
 
   const onSubmitHandler = e => {

--- a/web/components/Forms/RegisterForm/index.js
+++ b/web/components/Forms/RegisterForm/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Router from 'next/router';
 import axios from 'axios';
 import { TextField, OutlinedInput, InputAdornment, IconButton } from '@material-ui/core';
@@ -8,6 +8,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import validator from '../../../utils/validator';
 import { errorParser } from '../../../utils/error-parser';
 import { ERROR_DIFFERENT_PASSWORD } from '../../../utils/error-message';
+import { SUCCESS_REGISTER } from '../../../utils/success-message';
 import S from './styled';
 
 const useStyles = makeStyles(theme => ({
@@ -63,9 +64,9 @@ const RegisterForm = () => {
       const { id, password, name, email } = values;
       const body = { id, password, sub_email: email, name: name.trim() };
       await axios.post('/users', body);
-      Router.push('/login');
+      Router.push({ pathname: '/login', query: { message: SUCCESS_REGISTER } });
     } catch (err) {
-      const message = errorParser(err);
+      const { message } = errorParser(err);
       handleRegisterErrMsg(message);
     }
   };
@@ -99,7 +100,7 @@ const RegisterForm = () => {
       </S.InputContainer>
       <S.InputContainer>
         <TextField
-          id="outlined-search"
+          id="name"
           label="이름"
           type="search"
           onChange={handleInputChange('name')}
@@ -115,7 +116,7 @@ const RegisterForm = () => {
       </S.InputContainer>
       <S.InputContainer>
         <OutlinedInput
-          id="outlined-adornment-weight"
+          id="id"
           label="아이디"
           onChange={handleInputChange('id')}
           className={classes.textField}
@@ -133,7 +134,7 @@ const RegisterForm = () => {
       </S.InputContainer>
       <S.InputContainer>
         <TextField
-          id="outlined-password-input"
+          id="password"
           label="비밀번호"
           onChange={handleInputChange('password')}
           className={classes.textField}
@@ -144,7 +145,7 @@ const RegisterForm = () => {
           variant="outlined"
         />
         <TextField
-          id="outlined-password-input"
+          id="checkPassword"
           label="확인"
           onChange={handleInputChange('checkPassword')}
           className={classes.textField}
@@ -163,7 +164,7 @@ const RegisterForm = () => {
       </S.InputContainer>
       <S.InputContainer>
         <TextField
-          id="outlined-search"
+          id="email"
           label="이메일"
           type="search"
           onChange={handleInputChange('email')}

--- a/web/components/Forms/RegisterForm/index.js
+++ b/web/components/Forms/RegisterForm/index.js
@@ -12,10 +12,6 @@ import S from './styled';
 import request from '../../../utils/request';
 
 const useStyles = makeStyles(theme => ({
-  container: {
-    display: 'flex',
-    flexWrap: 'wrap',
-  },
   textField: {
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),

--- a/web/components/Forms/RegisterForm/index.js
+++ b/web/components/Forms/RegisterForm/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import Router from 'next/router';
 import { TextField, OutlinedInput, InputAdornment, IconButton } from '@material-ui/core';
 import { Visibility, VisibilityOff } from '@material-ui/icons';

--- a/web/components/MessageHeader/index.js
+++ b/web/components/MessageHeader/index.js
@@ -1,0 +1,24 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, { useState } from 'react';
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+import { useRouter } from 'next/router';
+
+import * as S from './styled';
+
+const MessageHeader = () => {
+  const router = useRouter();
+  const [message, setMessage] = useState(router.query.message || '');
+
+  return (
+    <S.TopContainer show={message !== ''}>
+      <S.Text>{message}</S.Text>
+      <HighlightOffIcon
+        size="20px"
+        style={{ cursor: 'pointer', marginRight: '20px', color: 'white' }}
+        onClick={() => setMessage('')}
+      />
+    </S.TopContainer>
+  );
+};
+
+export default MessageHeader;

--- a/web/components/MessageHeader/index.js
+++ b/web/components/MessageHeader/index.js
@@ -1,21 +1,22 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
-import { useRouter } from 'next/router';
 
 import * as S from './styled';
+import { AppDisapthContext, AppStateContext } from '../../contexts';
+import { setMessage } from '../../contexts/reducer';
 
 const MessageHeader = () => {
-  const router = useRouter();
-  const [message, setMessage] = useState(router.query.message || '');
+  const { state } = useContext(AppStateContext);
+  const { dispatch } = useContext(AppDisapthContext);
 
   return (
-    <S.TopContainer show={message !== ''}>
-      <S.Text>{message}</S.Text>
+    <S.TopContainer show={state.message !== ''}>
+      <S.Text>{state.message}</S.Text>
       <HighlightOffIcon
         size="20px"
         style={{ cursor: 'pointer', marginRight: '20px', color: 'white' }}
-        onClick={() => setMessage('')}
+        onClick={() => dispatch(setMessage(''))}
       />
     </S.TopContainer>
   );

--- a/web/components/MessageHeader/styled.js
+++ b/web/components/MessageHeader/styled.js
@@ -1,0 +1,34 @@
+import styled, { keyframes } from 'styled-components';
+
+const topToBottom = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(50px);
+  }
+`;
+
+const TopContainer = styled.div`
+  display: ${props => (props.show ? 'flex' : 'none')};
+  position: fixed;
+  left: 0;
+  top: -50px;
+
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 50px;
+  background-color: #7f8fa6;
+
+  animation: ${topToBottom} 1s normal forwards ease-in-out;
+`;
+
+const Text = styled.span`
+  font-size: 16px;
+  margin-left: 20px;
+  color: white;
+`;
+
+export { TopContainer, Text };

--- a/web/components/Profile/index.js
+++ b/web/components/Profile/index.js
@@ -52,7 +52,7 @@ const Profile = () => {
         </S.ColumnContainer>
         <S.ColumnContainer>
           <S.ColumnItem>
-            <Button>{name}</Button>
+            <Button style={{ textTransform: 'none' }}>{name}</Button>
           </S.ColumnItem>
           <S.ColumnItem>
             <Button onClick={() => router.push('/profile/pwchange')}>********</Button>

--- a/web/contexts/reducer.js
+++ b/web/contexts/reducer.js
@@ -3,6 +3,7 @@ const PAGE_NUMBER_CLICK = 'PAGE_NUMBER_CLICK';
 const CHANGE_MAILS_DATA = 'CHANGE_MAILS_DATA';
 const MAIL_CLICK = 'MAIL_CLICK';
 const SET_VIEW = 'SET_VIEW';
+const SET_MESSAGE = 'SET_MESSAGE';
 
 export const initialState = {
   category: 0,
@@ -10,6 +11,7 @@ export const initialState = {
   mails: null,
   paging: null,
   view: null,
+  message: '',
 };
 
 export const handleCategoryClick = (no, view) => {
@@ -61,6 +63,15 @@ export const setView = view => {
   };
 };
 
+export const setMessage = message => {
+  return {
+    type: SET_MESSAGE,
+    payload: {
+      message,
+    },
+  };
+};
+
 export const reducer = (state = initialState, action) => {
   const { type, payload } = action;
 
@@ -74,6 +85,8 @@ export const reducer = (state = initialState, action) => {
     case CHANGE_MAILS_DATA:
       return { ...state, ...payload };
     case SET_VIEW:
+      return { ...state, ...payload };
+    case SET_MESSAGE:
       return { ...state, ...payload };
     default:
       return { ...state };

--- a/web/pages/login.js
+++ b/web/pages/login.js
@@ -9,7 +9,7 @@ import * as S from '../components/GlobalStyle';
 
 const LoginPage = () => (
   <S.FlexCenterWrap>
-    <MessageHeader show={true}></MessageHeader>
+    <MessageHeader></MessageHeader>
     <SmallHeader />
     <LoginForm />
     <S.HorizontalLine />

--- a/web/pages/login.js
+++ b/web/pages/login.js
@@ -3,11 +3,13 @@ import React from 'react';
 import LoginForm from '../components/Forms/LoginForm';
 import SmallHeader from '../components/SmallHeader';
 import LinkArea from '../components/LinkArea';
+import MessageHeader from '../components/MessageHeader';
 
 import * as S from '../components/GlobalStyle';
 
 const LoginPage = () => (
   <S.FlexCenterWrap>
+    <MessageHeader show={true}></MessageHeader>
     <SmallHeader />
     <LoginForm />
     <S.HorizontalLine />

--- a/web/utils/success-message.js
+++ b/web/utils/success-message.js
@@ -1,0 +1,3 @@
+const SUCCESS_REGISTER = '회원가입이 완료되었습니다. 환영합니다! ';
+
+export { SUCCESS_REGISTER };


### PR DESCRIPTION
### 무엇을 (What)
1. 회원가입 후 로그인 페이지에서 메시지 표시
2. 사용자에게 보여줄 메시지를 ContextAPI를 사용하여 관리하도록 함
3. Router event (routeChangeStart)를 사용하여 페이지 이동시 메시지 상태를 초기화 하도록 함 
4. 다른 페이지에서 로그인 페이지로 이동시에는 메시지 상태를 초기화 하지 않도록 함
 
### 왜 그 방법을 선택했는가? (Why)
1. Router를 통해 query를 push할 경우 URL에 query가 표시되어서 더러워짐
2. routeChangeStart에서 메시지를 다시 초기화 하기 때문에 메시지 설정 후 "로그인 페이지"로 이동할 때에는 제외 하도록 함 
```javascript
const handleRouteChange = url => {
  if (url !== '/login') {
    dispatch(setMessage(''));
  }
};

Router.events.on('routeChangeStart', handleRouteChange);
```

### 리뷰어 참고사항
1. next/router의 Router 객체는 여러가지 이벤트를 다음과 같이 여러가지 이벤트를 등록할 수 있음
`routeChangeStart(url)`: Fires when a route starts to change
`routeChangeComplete(url)`: Fires when a route changed completely
`routeChangeError(err, url)`: Fires when there's an error when changing routes, or a route load is cancelled
`beforeHistoryChange(url)`: Fires just before changing the browser's history
`hashChangeStart(url)`: Fires when the hash will change but not the page
`hashChangeComplete(url)`: Fires when the hash has changed but not the page 

[참고](https://nextjs.org/docs#router-events)

