### PR TITLE
FE 파일확장자 & 사이즈 검사 로직추가

### DIFF
--- a/web/components/WriteMail/DropZone/index.js
+++ b/web/components/WriteMail/DropZone/index.js
@@ -16,9 +16,20 @@ import * as WM_S from '../styled';
 import * as S from './styled';
 import { useStateForWM, useDispatchForWM } from '../ContextProvider';
 import { UPDATE_FILES } from '../ContextProvider/reducer/action-type';
+import AVAILABLE_EXTENSION from '../../../utils/available-extension';
 
 const MB = 1024 * 1024;
-const FILE_MAX_SIZE = 20 * MB;
+const FILE_MAX_SIZE = 10 * MB;
+
+const checkOverSize = files => {
+  const sum = files.reduce((a, b) => a + b.size, 0);
+  return sum <= FILE_MAX_SIZE;
+};
+
+const checkExtension = files => {
+  const filterdFiles = files.filter(file => !AVAILABLE_EXTENSION[file.type]);
+  return filterdFiles.length === 0;
+};
 
 const DropZone = () => {
   const { files } = useStateForWM();
@@ -26,6 +37,13 @@ const DropZone = () => {
 
   const onDrop = useCallback(
     acceptedFiles => {
+      if (!checkOverSize(acceptedFiles)) {
+        return;
+      }
+      if (!checkExtension(acceptedFiles)) {
+        return;
+      }
+
       dispatch({ type: UPDATE_FILES, payload: { files: acceptedFiles } });
     },
     [dispatch],

--- a/web/components/WriteMail/DropZone/index.js
+++ b/web/components/WriteMail/DropZone/index.js
@@ -26,10 +26,7 @@ const checkOverSize = files => {
   return sum <= FILE_MAX_SIZE;
 };
 
-const checkExtension = files => {
-  const filterdFiles = files.filter(file => !AVAILABLE_EXTENSION[file.type]);
-  return filterdFiles.length === 0;
-};
+const checkExtension = files => files.every(file => AVAILABLE_EXTENSION[file.type]);
 
 const DropZone = () => {
   const { files } = useStateForWM();

--- a/web/utils/available-extension.js
+++ b/web/utils/available-extension.js
@@ -1,0 +1,16 @@
+export default {
+  'text/plain': true,
+  'text/csv': true,
+  'text/html': true,
+  'application/vnd.ms-powerpoint': true,
+  'application/pdf': true,
+  'application/x-font-ttf': true,
+  'application/zip': true,
+  'application/json': true,
+  'image/jpeg': true,
+  'image/png': true,
+  'image/jpg': true,
+  'image/bmp': true,
+  'image/gif': true,
+  '': true,
+};

--- a/web/utils/request.js
+++ b/web/utils/request.js
@@ -39,7 +39,7 @@ export default {
   },
 
   async put(url, body, options) {
-    const fn = () => axios.put(url, { ...defaultOptions, ...options });
+    const fn = () => axios.put(url, body, { ...defaultOptions, ...options });
     const response = await execute(fn);
     return response;
   },
@@ -51,7 +51,7 @@ export default {
   },
 
   async patch(url, body, options) {
-    const fn = () => axios.patch(url, { ...defaultOptions, ...options });
+    const fn = () => axios.patch(url, body, { ...defaultOptions, ...options });
     const response = await execute(fn);
     return response;
   },


### PR DESCRIPTION
### 무엇을 (What)
1.이미지 업로드시 확장자와 사이즈 검사

### 왜 그 방법을 선택했는가? (Why)
1. 허용가능한 범위의 파일만 받음
2. 확장자를 아무거나 받으면 보안에 위협적

### 리뷰어 참고사항

