### PR TITLE
[FE] 로그인 시 카테고리 목록 로드

### DIFF
--- a/web/components/Aside/index.js
+++ b/web/components/Aside/index.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useCallback } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { List, ListItem, ListItemIcon, ListItemText, Collapse } from '@material-ui/core';
 import { ExpandLess, ExpandMore, StarBorder } from '@material-ui/icons';
@@ -10,8 +10,13 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import S from './styled';
 import MailArea from '../MailArea';
 import WriteMail from '../WriteMail';
+import useFetch from '../../utils/use-fetch';
+import Loading from '../Loading';
 import { AppDisapthContext } from '../../contexts';
 import { handleCategoryClick, setView } from '../../contexts/reducer';
+import { handleErrorStatus } from '../../utils/error-handler';
+
+const URL = '/users/categories';
 
 const useStyles = makeStyles(theme => ({
   nested: {
@@ -19,10 +24,24 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const setCategories = ({ categories }) => {
+  console.log(categories);
+};
+
 const Aside = () => {
   const classes = useStyles();
   const [open, setOpen] = React.useState(true);
   const { dispatch } = useContext(AppDisapthContext);
+  const callback = useCallback(
+    (err, data) => (err ? handleErrorStatus(err) : setCategories(data)),
+    [],
+  );
+  const isLoading = useFetch(callback, URL);
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
   const handleClick = () => {
     setOpen(!open);
   };

--- a/web/components/Aside/index.js
+++ b/web/components/Aside/index.js
@@ -16,7 +16,7 @@ import { AppDisapthContext } from '../../contexts';
 import { handleCategoryClick, setView } from '../../contexts/reducer';
 import { handleErrorStatus } from '../../utils/error-handler';
 
-const URL = '/users/categories';
+const URL = '/mail/categories';
 const defaultCategories = [{ name: '전체메일함', no: 0 }];
 const userDefinedCategories = [];
 const iconOfDefaultCategories = [

--- a/web/components/Aside/index.js
+++ b/web/components/Aside/index.js
@@ -17,6 +17,15 @@ import { handleCategoryClick, setView } from '../../contexts/reducer';
 import { handleErrorStatus } from '../../utils/error-handler';
 
 const URL = '/users/categories';
+const defaultCategories = [{ name: '전체메일함', no: 0 }];
+const userDefinedCategories = [];
+const iconOfDefaultCategories = [
+  <AllInboxIcon />,
+  <StarBorder />,
+  <SendIcon />,
+  <DraftsIcon />,
+  <DeleteIcon />,
+];
 
 const useStyles = makeStyles(theme => ({
   nested: {
@@ -25,7 +34,13 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const setCategories = ({ categories }) => {
-  console.log(categories);
+  categories.forEach(category => {
+    if (category.is_default) {
+      defaultCategories.push(category);
+    } else {
+      userDefinedCategories.push(category);
+    }
+  });
 };
 
 const Aside = () => {
@@ -46,31 +61,21 @@ const Aside = () => {
     setOpen(!open);
   };
 
-  const defaultCategory = [
-    { name: '받은편지함', icon: <AllInboxIcon />, no: 0 },
-    { name: '중요편지함', icon: <StarBorder />, no: 1 },
-    { name: '보낸메일함', icon: <SendIcon />, no: 2 },
-    { name: '내게쓴메일함', icon: <DraftsIcon />, no: 3 },
-    { name: '휴지통', icon: <DeleteIcon />, no: 4 },
-  ];
-
-  const userCategory = [
-    { name: '대햇', icon: <StarBorder />, no: 5 },
-    { name: '흑우', icon: <StarBorder />, no: 6 },
-  ];
-
-  const defaultCard = defaultCategory.map((category, idx) => (
+  const defaultCards = defaultCategories.map((category, idx) => (
     <ListItem
       button
       key={idx}
       onClick={() => dispatch(handleCategoryClick(category.no, <MailArea />))}>
-      <ListItemIcon>{category.icon}</ListItemIcon>
+      <ListItemIcon>{iconOfDefaultCategories[idx]}</ListItemIcon>
       <ListItemText primary={category.name} />
     </ListItem>
   ));
-  const userCategoryCard = userCategory.map((category, idx) => (
+
+  const userDefinedCategoryCards = userDefinedCategories.map((category, idx) => (
     <ListItem button key={idx} className={classes.nested}>
-      <ListItemIcon>{category.icon}</ListItemIcon>
+      <ListItemIcon>
+        <StarBorder />
+      </ListItemIcon>
       <ListItemText primary={category.name} />
     </ListItem>
   ));
@@ -82,7 +87,7 @@ const Aside = () => {
           <S.WrtieButton onClick={() => dispatch(setView(<WriteMail />))}>편지쓰기</S.WrtieButton>
           <S.WrtieButton>내게쓰기</S.WrtieButton>
         </ListItem>
-        {defaultCard}
+        {defaultCards}
         <ListItem button onClick={handleClick}>
           <ListItemIcon>
             <InboxIcon />
@@ -92,7 +97,7 @@ const Aside = () => {
         </ListItem>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
-            {userCategoryCard}
+            {userDefinedCategoryCards}
           </List>
         </Collapse>
       </List>

--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -53,9 +53,9 @@ const getDateOrTime = createdAt => {
 
 const MailTemplate = ({ mail }) => {
   const { dispatch } = useContext(AppDisapthContext);
-  const { is_important, is_read, MailTemplate } = mail;
+  const { is_important, is_read, MailTemplate, no } = mail;
   const { from, to, subject, text, createdAt } = MailTemplate;
-  const mailToRead = { from, to, subject, text, createdAt, is_important };
+  const mailToRead = { from, to, subject, text, createdAt, is_important, no };
   const handleSubjectClick = () => dispatch(handleMailClick(mailToRead, <ReadMail />));
   const classes = useStyles();
 

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -24,7 +24,11 @@ const SORT_TYPES = [
   { value: 'fromasc', name: '보낸 이 순정렬' },
 ];
 
-const sortItems = SORT_TYPES.map(type => <MenuItem value={type.value}>{type.name}</MenuItem>);
+const sortItems = SORT_TYPES.map(type => (
+  <MenuItem key={type.value} value={type.value}>
+    {type.name}
+  </MenuItem>
+));
 
 const Tools = () => {
   const classes = useStyles();

--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -10,16 +10,7 @@ import { handleMailsChange } from '../../contexts/reducer';
 import useFetch from '../../utils/use-fetch';
 import getQueryByOptions from '../../utils/query';
 import Tools from './Tools';
-
-const actionByErrorStatus = ({ status, message }) => {
-  switch (status) {
-    case 401:
-      Router.push('/login');
-      break;
-    default:
-      break;
-  }
-};
+import { handleErrorStatus } from '../../utils/error-handler';
 
 const MailArea = () => {
   const { state } = useContext(AppStateContext);
@@ -27,7 +18,7 @@ const MailArea = () => {
   const query = getQueryByOptions(state);
   const URL = `/mail?${query}`;
   const callback = useCallback(
-    (err, data) => (err ? actionByErrorStatus(err) : dispatch(handleMailsChange({ ...data }))),
+    (err, data) => (err ? handleErrorStatus(err) : dispatch(handleMailsChange({ ...data }))),
     [dispatch],
   );
 

--- a/web/components/ReadMail/PageMoveButtonArea/index.js
+++ b/web/components/ReadMail/PageMoveButtonArea/index.js
@@ -4,7 +4,7 @@ import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import * as S from './styled';
 
-const PageMoveButtonArea = () => {
+const PageMoveButtonArea = ({ no }) => {
   return (
     <S.Container>
       <IconButton>

--- a/web/components/ReadMail/ToolGroup/index.js
+++ b/web/components/ReadMail/ToolGroup/index.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import * as S from './styled';
 
 const buttonNames = ['답장', '전체답장', '전달', '삭제'];
-const buttonSet = buttonNames.map(name => <button>{name}</button>);
+const buttonSet = buttonNames.map((name, i) => <button key={i}>{name}</button>);
 
 const ToolGroup = () => {
   return (

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -1,14 +1,14 @@
 import React, { useContext } from 'react';
+import moment from 'moment';
 import { StarBorder } from '@material-ui/icons';
 import * as S from './styled';
 import PageMoveButtonArea from './PageMoveButtonArea';
 import { AppStateContext } from '../../contexts';
-import moment from 'moment';
 import ToolGroup from './ToolGroup';
 
 const ReadMail = () => {
   const { state } = useContext(AppStateContext);
-  const { to, from, subject, createdAt, text } = state.mail;
+  const { to, from, subject, createdAt, text, no } = state.mail;
   const receivers = to.replace(',', ', ');
   const date = moment(createdAt)
     .utc()
@@ -35,7 +35,7 @@ const ReadMail = () => {
         </S.TitleView>
         <S.ReadFrame>{text}</S.ReadFrame>
       </S.ReadArea>
-      <PageMoveButtonArea />
+      <PageMoveButtonArea no={no} />
     </S.Container>
   );
 };

--- a/web/utils/error-handler.js
+++ b/web/utils/error-handler.js
@@ -1,0 +1,11 @@
+const handleErrorStatus = ({ status, message }) => {
+  switch (status) {
+    case 401:
+      Router.push('/login');
+      break;
+    default:
+      break;
+  }
+};
+
+export { handleErrorStatus };

--- a/web/utils/error-handler.js
+++ b/web/utils/error-handler.js
@@ -1,3 +1,5 @@
+import Router from 'next/router';
+
 const handleErrorStatus = ({ status, message }) => {
   switch (status) {
     case 401:


### PR DESCRIPTION
### 무엇을 (What)
1. 로그인 시 해당 유저가 가지고 있는 카테고리 목록들을 받아와 aside에서 출력한다.

### 왜 그 방법을 선택했는가? (Why)
1. 유저 별로 같은 default 카테고리이어도 category.no가 다르기 때문에 유저별 카테고리 목록을 로드할 필요가 있었다. 이를 위해 utils의 useFetch를 이용하였고 useCallback을 통해 계속해서 데이터를 요청하는 것을 방지

### 리뷰어 참고사항
차후에는 카테고리 목록을 context에 넣어서 관리를 할 생각이다. 카테고리를 추가하거나 삭제하면 aside가 재렌더링 되어야 되기 때문에...
