### PR TITLE
[이정환]w4_리뷰요청_회원가입_메시지_보여주기

### DIFF
--- a/review/frontend/LoginForm/index.js
+++ b/review/frontend/LoginForm/index.js
@@ -1,0 +1,108 @@
+﻿import React, { useContext } from 'react';
+import Router from 'next/router';
+import useForm from 'react-hook-form';
+
+import {
+  ERROR_ID_EMPTY,
+  ERROR_PASSWORD_EMPTY,
+  ERROR_ID_VALIDATION,
+  ERROR_PASSWORD_VALIDATION,
+} from '../../../utils/error-message';
+import validator from '../../../utils/validator';
+import S from './styled';
+import storage from '../../../utils/storage';
+import request from '../../../utils/request';
+import { setMessage } from '../../../contexts/reducer';
+import { AppDisapthContext } from '../../../contexts';
+
+const LoignForm = () => {
+  const { register, handleSubmit, errors, setError, clearError } = useForm();
+  const { dispatch } = useContext(AppDisapthContext);
+
+  const handleRouteChange = url => {
+    if (url !== '/login') {
+      dispatch(setMessage(''));
+    }
+  };
+
+  Router.events.on('routeChangeStart', handleRouteChange);
+
+  const onSubmit = (data, e) => {
+    const { userId, password } = data;
+
+    e.preventDefault();
+
+    if (validateForm(userId, password)) {
+      signIn(userId, password);
+    }
+  };
+
+  const validateForm = (id, password) => {
+    let checkId;
+    let checkPassword;
+
+    if (id.length === 0) {
+      setError('userId', 'notMatch', ERROR_ID_EMPTY);
+    } else if (!validator.validate('id', id)) {
+      setError('userId', 'validation', ERROR_ID_VALIDATION);
+    } else {
+      clearError('userId');
+      checkId = true;
+    }
+
+    if (password.length === 0) {
+      setError('password', 'notMatch', ERROR_PASSWORD_EMPTY);
+    } else if (!validator.validate('password', password)) {
+      setError('password', 'validation', ERROR_PASSWORD_VALIDATION);
+    } else {
+      clearError('password');
+      checkPassword = true;
+    }
+
+    return checkId && checkPassword;
+  };
+
+  const signIn = async (id, password) => {
+    const body = { id, password };
+    const { isError, data } = await request.post('/auth/login', body);
+    if (isError) {
+      setError('login', 'api', data.message);
+      return;
+    }
+    storage.setUser(data);
+    Router.push('/');
+  };
+
+  return (
+    <S.InputForm onSubmit={handleSubmit(onSubmit)}>
+      <S.Input
+        type="text"
+        className="form-control"
+        id="userId"
+        placeholder="아이디"
+        name="userId"
+        maxLength={20}
+        ref={register}
+        autoComplete="off"
+      />
+      <S.ErrorText>{errors.userId && errors.userId.message}</S.ErrorText>
+      <S.Input
+        type="password"
+        className="form-control"
+        id="password"
+        placeholder="비밀번호"
+        name="password"
+        maxLength={20}
+        ref={register}
+        autoComplete="off"
+      />
+      <S.ErrorText>
+        {(errors.password && errors.password.message) || (errors.login && errors.login.message)}
+      </S.ErrorText>
+      <S.Button className="submit-btn max-width" onSubmit={handleSubmit(onSubmit)}>
+        로그인
+      </S.Button>
+    </S.InputForm>
+  );
+};
+export default LoignForm;

--- a/review/frontend/MessageHeader/index.js
+++ b/review/frontend/MessageHeader/index.js
@@ -1,0 +1,25 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, { useContext } from 'react';
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+
+import * as S from './styled';
+import { AppDisapthContext, AppStateContext } from '../../contexts';
+import { setMessage } from '../../contexts/reducer';
+
+const MessageHeader = () => {
+  const { state } = useContext(AppStateContext);
+  const { dispatch } = useContext(AppDisapthContext);
+
+  return (
+    <S.TopContainer show={state.message !== ''}>
+      <S.Text>{state.message}</S.Text>
+      <HighlightOffIcon
+        size="20px"
+        style={{ cursor: 'pointer', marginRight: '20px', color: 'white' }}
+        onClick={() => dispatch(setMessage(''))}
+      />
+    </S.TopContainer>
+  );
+};
+
+export default MessageHeader;

--- a/review/frontend/RegisterForm/index.js
+++ b/review/frontend/RegisterForm/index.js
@@ -1,0 +1,187 @@
+import React, { useState, useContext } from 'react';
+import Router from 'next/router';
+import { TextField, OutlinedInput, InputAdornment, IconButton } from '@material-ui/core';
+import { Visibility, VisibilityOff } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+
+import validator from '../../../utils/validator';
+import { errorParser } from '../../../utils/error-parser';
+import { ERROR_DIFFERENT_PASSWORD } from '../../../utils/error-message';
+import { SUCCESS_REGISTER } from '../../../utils/success-message';
+import S from './styled';
+import request from '../../../utils/request';
+import { setMessage } from '../../../contexts/reducer';
+import { AppDisapthContext } from '../../../contexts';
+
+const useStyles = makeStyles(theme => ({
+  textField: {
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+    width: '100%',
+  },
+}));
+
+const initialInputState = {
+  name: '',
+  id: '',
+  password: '',
+  checkPassword: '',
+  email: '',
+  showPassword: false,
+};
+
+const initialErrorState = {
+  name: '',
+  id: '',
+  password: '',
+  email: '',
+  checkPassword: '',
+  register: '',
+};
+
+const RegisterForm = () => {
+  const classes = useStyles();
+  const { dispatch } = useContext(AppDisapthContext);
+
+  const [values, setValues] = useState(initialInputState);
+  const [errors, setErrorMsg] = useState(initialErrorState);
+
+  const handleInputChange = prop => ({ target }) => {
+    setValues({ ...values, [prop]: target.value });
+  };
+
+  const handleClickShowPassword = () => {
+    setValues({ ...values, showPassword: !values.showPassword });
+  };
+
+  const handleRegisterErrMsg = msg => {
+    setErrorMsg({ ...initialErrorState, register: msg });
+  };
+
+  const signUp = async () => {
+    const { id, password, name, email } = values;
+    const body = { id, password, sub_email: email, name: name.trim() };
+    const { isError, data } = await request.post('/users', body);
+    if (isError) {
+      const { message } = errorParser(data);
+      handleRegisterErrMsg(message);
+      return;
+    }
+    dispatch(setMessage(SUCCESS_REGISTER));
+    Router.push('/login');
+  };
+
+  const onSubmitHandler = e => {
+    e.preventDefault();
+
+    if (validateForm()) {
+      signUp();
+    }
+  };
+
+  const validateForm = () => {
+    const errMsgs = { id: '', password: '', name: '', email: '' };
+    const userForm = { ...values, name: values.name.trim() };
+    Object.keys(errMsgs).forEach(key => {
+      errMsgs[key] = validator.validateAndGetMsg(key, userForm[key], true);
+    });
+    errMsgs.checkPassword = '';
+    if (values.password !== values.checkPassword) {
+      errMsgs.checkPassword = ERROR_DIFFERENT_PASSWORD;
+    }
+    setErrorMsg(errMsgs);
+    return Object.keys(errMsgs).every(key => errMsgs[key] === '');
+  };
+
+  return (
+    <S.InputForm autoComplete="off">
+      <S.InputContainer>
+        <S.Title>Daitnu 계정 만들기</S.Title>
+      </S.InputContainer>
+      <S.InputContainer>
+        <TextField
+          id="name"
+          label="이름"
+          type="search"
+          onChange={handleInputChange('name')}
+          className={classes.textField}
+          error={errors.name !== ''}
+          margin="normal"
+          variant="outlined"
+          autoComplete="off"
+        />
+      </S.InputContainer>
+      <S.InputContainer>
+        <S.ErrorText>{errors.name}</S.ErrorText>
+      </S.InputContainer>
+      <S.InputContainer>
+        <OutlinedInput
+          id="id"
+          label="아이디"
+          onChange={handleInputChange('id')}
+          className={classes.textField}
+          error={errors.id !== ''}
+          endAdornment={<InputAdornment position="end">@daitnu.com</InputAdornment>}
+          aria-describedby="filled-weight-helper-text"
+          inputProps={{
+            'aria-label': 'weight',
+          }}
+          autoComplete="off"
+        />
+      </S.InputContainer>
+      <S.InputContainer>
+        <S.ErrorText>{errors.id}</S.ErrorText>
+      </S.InputContainer>
+      <S.InputContainer>
+        <TextField
+          id="password"
+          label="비밀번호"
+          onChange={handleInputChange('password')}
+          className={classes.textField}
+          error={errors.password !== ''}
+          type={values.showPassword ? 'text' : 'password'}
+          autoComplete="off"
+          margin="normal"
+          variant="outlined"
+        />
+        <TextField
+          id="checkPassword"
+          label="확인"
+          onChange={handleInputChange('checkPassword')}
+          className={classes.textField}
+          error={errors.checkPassword !== ''}
+          type={values.showPassword ? 'text' : 'password'}
+          autoComplete="off"
+          margin="normal"
+          variant="outlined"
+        />
+        <IconButton aria-label="toggle password visibility" onClick={handleClickShowPassword}>
+          {values.showPassword ? <Visibility /> : <VisibilityOff />}
+        </IconButton>
+      </S.InputContainer>
+      <S.InputContainer>
+        <S.ErrorText>{errors.password || errors.checkPassword}</S.ErrorText>
+      </S.InputContainer>
+      <S.InputContainer>
+        <TextField
+          id="email"
+          label="이메일"
+          type="search"
+          onChange={handleInputChange('email')}
+          className={classes.textField}
+          error={errors.email !== ''}
+          margin="normal"
+          variant="outlined"
+          autoComplete="off"
+        />
+      </S.InputContainer>
+      <S.InputContainer>
+        <S.ErrorText>{errors.register || errors.email}</S.ErrorText>
+      </S.InputContainer>
+      <S.Button className="submit-btn max-width" onClick={onSubmitHandler}>
+        가입하기
+      </S.Button>
+    </S.InputForm>
+  );
+};
+export default RegisterForm;

--- a/review/frontend/contexts/index.js
+++ b/review/frontend/contexts/index.js
@@ -1,0 +1,17 @@
+import React, { useReducer, createContext } from 'react';
+import { reducer, initialState } from './reducer';
+
+const AppStateContext = createContext();
+const AppDisapthContext = createContext();
+
+const AppProvider = props => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <AppStateContext.Provider value={{ state }}>
+      <AppDisapthContext.Provider value={{ dispatch }}>{props.children}</AppDisapthContext.Provider>
+    </AppStateContext.Provider>
+  );
+};
+
+export { AppProvider, AppStateContext, AppDisapthContext };

--- a/review/frontend/contexts/reducer.js
+++ b/review/frontend/contexts/reducer.js
@@ -18,64 +18,7 @@ export const initialState = {
   message: '',
 };
 
-export const handleSortSelect = sortType => {
-  return {
-    type: SORT_SELECT,
-    payload: {
-      page: 1,
-      sort: sortType,
-    },
-  };
-};
-
-export const handleCategoryClick = (no, view) => {
-  return {
-    type: CATEGORY_CLICK,
-    payload: {
-      category: no,
-      page: 1,
-      view,
-    },
-  };
-};
-
-export const handleCategoriesChange = ({ categories }) => {
-  return {
-    type: CHANGE_CATEGORIES_DATA,
-    payload: {
-      categories,
-    },
-  };
-};
-
-export const handleMailsChange = ({ mails, paging }) => {
-  return {
-    type: CHANGE_MAILS_DATA,
-    payload: {
-      mails,
-      paging,
-    },
-  };
-};
-
-export const handlePageNumberClick = page => {
-  return {
-    type: PAGE_NUMBER_CLICK,
-    payload: {
-      page,
-    },
-  };
-};
-
-export const handleMailClick = (mail, view) => {
-  return {
-    type: MAIL_CLICK,
-    payload: {
-      mail,
-      view,
-    },
-  };
-};
+// ...
 
 export const setView = view => {
   return {

--- a/review/frontend/contexts/reducer.js
+++ b/review/frontend/contexts/reducer.js
@@ -1,0 +1,121 @@
+const CATEGORY_CLICK = 'CATEGORY_CLICK';
+const PAGE_NUMBER_CLICK = 'PAGE_NUMBER_CLICK';
+const CHANGE_MAILS_DATA = 'CHANGE_MAILS_DATA';
+const CHANGE_CATEGORIES_DATA = 'CHANGE_CATEGORIES_DATA';
+const MAIL_CLICK = 'MAIL_CLICK';
+const SET_VIEW = 'SET_VIEW';
+const SORT_SELECT = 'SORT_SELECT';
+const SET_MESSAGE = 'SET_MESSAGE';
+
+export const initialState = {
+  categories: null,
+  category: 0,
+  page: 1,
+  mails: null,
+  paging: null,
+  view: null,
+  sort: 'datedesc',
+  message: '',
+};
+
+export const handleSortSelect = sortType => {
+  return {
+    type: SORT_SELECT,
+    payload: {
+      page: 1,
+      sort: sortType,
+    },
+  };
+};
+
+export const handleCategoryClick = (no, view) => {
+  return {
+    type: CATEGORY_CLICK,
+    payload: {
+      category: no,
+      page: 1,
+      view,
+    },
+  };
+};
+
+export const handleCategoriesChange = ({ categories }) => {
+  return {
+    type: CHANGE_CATEGORIES_DATA,
+    payload: {
+      categories,
+    },
+  };
+};
+
+export const handleMailsChange = ({ mails, paging }) => {
+  return {
+    type: CHANGE_MAILS_DATA,
+    payload: {
+      mails,
+      paging,
+    },
+  };
+};
+
+export const handlePageNumberClick = page => {
+  return {
+    type: PAGE_NUMBER_CLICK,
+    payload: {
+      page,
+    },
+  };
+};
+
+export const handleMailClick = (mail, view) => {
+  return {
+    type: MAIL_CLICK,
+    payload: {
+      mail,
+      view,
+    },
+  };
+};
+
+export const setView = view => {
+  return {
+    type: SET_VIEW,
+    payload: {
+      view,
+    },
+  };
+};
+
+export const setMessage = message => {
+  return {
+    type: SET_MESSAGE,
+    payload: {
+      message,
+    },
+  };
+};
+
+export const reducer = (state = initialState, action) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case CATEGORY_CLICK:
+      return { ...state, ...payload };
+    case PAGE_NUMBER_CLICK:
+      return { ...state, ...payload };
+    case MAIL_CLICK:
+      return { ...state, ...payload };
+    case CHANGE_MAILS_DATA:
+      return { ...state, ...payload };
+    case SET_VIEW:
+      return { ...state, ...payload };
+    case SORT_SELECT:
+      return { ...state, ...payload };
+    case SET_MESSAGE:
+      return { ...state, ...payload };
+    case CHANGE_CATEGORIES_DATA:
+      return { ...state, ...payload };
+    default:
+      return { ...state };
+  }
+};

--- a/review/frontend/contexts/reducer.js
+++ b/review/frontend/contexts/reducer.js
@@ -46,14 +46,9 @@ export const reducer = (state = initialState, action) => {
       return { ...state, ...payload };
     case PAGE_NUMBER_CLICK:
       return { ...state, ...payload };
-    case MAIL_CLICK:
-      return { ...state, ...payload };
-    case CHANGE_MAILS_DATA:
-      return { ...state, ...payload };
-    case SET_VIEW:
-      return { ...state, ...payload };
-    case SORT_SELECT:
-      return { ...state, ...payload };
+
+    // ...
+
     case SET_MESSAGE:
       return { ...state, ...payload };
     case CHANGE_CATEGORIES_DATA:

--- a/review/pages/login.js
+++ b/review/pages/login.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import LoginForm from '../components/Forms/LoginForm';
+import SmallHeader from '../components/SmallHeader';
+import LinkArea from '../components/LinkArea';
+import MessageHeader from '../components/MessageHeader';
+
+import * as S from '../components/GlobalStyle';
+
+const LoginPage = () => (
+  <S.FlexCenterWrap>
+    <MessageHeader></MessageHeader>
+    <SmallHeader />
+    <LoginForm />
+    <S.HorizontalLine />
+    <LinkArea />
+  </S.FlexCenterWrap>
+);
+
+export default LoginPage;


### PR DESCRIPTION
### 개발 상황
1. 회원가입을 성공했을 경우 로그인 페이지로 이동 후 화면 상단에 MessageHeader 컴포넌트를 사용하여 회원가입 성공 메시지 표시를 하도록 하였습니다. MessageHeader 컴포넌트는 나중에 에러 메시지 표시 용도로 사용할 수도 있게 할 예정입니다.

### 질문
1. 회원가입을 성공했을 때 로그인 페이지로 이동 후 메시지를 보여주기 위해 Context API를 통해 메시지 정보를 설정하여 로그인 페이지에 있는 MessageHeader 컴포넌트를 통해 Context API에 등록된 메시지 정보가 있을 경우 메시지를 보여줍니다. 그리고 페이지 이동 시 이벤트를 등록하여 로그인 페이지에서 벗어날 때 Context에서 제공하는 dispatch 함수를 사용하여 메시지 정보를 삭제하도록 하였습니다. (*LoginForm/index.js의 handleRouteChange 함수*)

	nextjs에서 push 함수를 사용하여 URL에 query를 넣어서 query에 따라 메시지를 보여주는 방식도 사용해보았는데 URL에 query 정보가 남아서 보기가 좋지 않았고 페이지 이동 후 뒤로가기를 하면 URL에 query 정보가 남아 있어서 메시지가 보였습니다.

	현재는 페이지 이동 시 따로 이벤트를 처리하도록 만들었는데 Context API를 사용하지 않고 페이지 이동 후 해당 페이지에서 메시지를 보여주기 위해 더 좋은 방법이 있는지 궁금합니다.