### PR TITLE
[Infra] 메일 수신 시 첨부파일 DB 저장

### DIFF
--- a/infra/maildb/node-runner.sh
+++ b/infra/maildb/node-runner.sh
@@ -1,10 +1,4 @@
 #!/bin/sh
 
-# environment variables
-DB_DEV_USERNAME=""
-DB_DEV_PW=""
-DB_DEV_SCHEMA=""
-DB_DEV_HOST=""
-
 # the mail will be in the $1 variable
-node src/app.js "`cat $1`" $DB_DEV_USERNAME $DB_DEV_PW $DB_DEV_SCHEMA $DB_DEV_HOST > log 2>&1
+node src/app.js "`cat $1`" > log 2>&1

--- a/infra/maildb/src/app.js
+++ b/infra/maildb/src/app.js
@@ -13,6 +13,7 @@ const {
 const MAIL_CONTENT = process.argv[2];
 const MY_DOMAIN = "daitnu.com";
 const RECEIVED_KEY = "received";
+const MESSAGE_ID_KEY = "message-id";
 const UNTITLE = "";
 const EXP_EXTRACT_RECEIVER = /<.{3,40}@.{3,40}>/;
 
@@ -68,21 +69,29 @@ const getReceivers = ({ headers, to }) => {
 };
 
 const recordLog = mail => {
-  const { from, to, mail_template_id, owner, category_no } = mail;
+  const { from, to, mail_template_id, owner, category_no, message_id } = mail;
   console.log(
     JSON.stringify({
       from,
       to,
       mail_template_id,
       owner,
-      category_no
+      category_no,
+      message_id
     })
   );
+};
+
+const setMessageIdOfMail = mail => {
+  const { headers } = mail;
+  const messageId = headers.get(MESSAGE_ID_KEY);
+  mail.message_id = messageId.slice(1, -1);
 };
 
 const insertMailToDB = async content => {
   const mail = await parseMailContent(content);
   const receivers = getReceivers(mail);
+  setMessageIdOfMail(mail);
   const connection = await pool.getConnection(async conn => conn);
   let queryFormat;
 

--- a/infra/maildb/src/app.js
+++ b/infra/maildb/src/app.js
@@ -1,19 +1,18 @@
 const simpleParser = require("mailparser").simpleParser;
 const mysql = require("mysql2/promise");
 const format = require("./format");
+const { multipartUpload } = require("./ncloud");
 
-const [
-  ORIGIN,
-  FILE_NAME,
-  MAIL_CONTENT,
+const {
   DB_DEV_USERNAME,
   DB_DEV_PW,
   DB_DEV_SCHEMA,
   DB_DEV_HOST
-] = process.argv;
+} = require("./env");
 
+const MAIL_CONTENT = process.argv[2];
 const MY_DOMAIN = "daitnu.com";
-const RECEIVED_KEY = 'received';
+const RECEIVED_KEY = "received";
 const UNTITLE = "";
 const EXP_EXTRACT_RECEIVER = /<.{3,40}@.{3,40}>/;
 
@@ -26,9 +25,15 @@ const pool = mysql.createPool({
 
 const parseMailContent = async content => {
   try {
-    const { from, to, subject, html, text, attachments, headers } = await simpleParser(
-      content
-    );
+    const {
+      from,
+      to,
+      subject,
+      html,
+      text,
+      attachments,
+      headers
+    } = await simpleParser(content);
     return {
       from: from.text,
       to: to.text,
@@ -48,7 +53,7 @@ const addReceiver = (receviers, email) => {
   if (domain === MY_DOMAIN) {
     receviers.push(id);
   }
-}
+};
 
 const getReceivers = ({ headers, to }) => {
   const receivedOfHeader = headers.get(RECEIVED_KEY)[0];
@@ -62,12 +67,15 @@ const getReceivers = ({ headers, to }) => {
   return receivers;
 };
 
-const recordLog = (mail, log) => {
+const recordLog = mail => {
+  const { from, to, mail_template_id, owner, category_no } = mail;
   console.log(
     JSON.stringify({
-      from: mail.from,
-      to: mail.to,
-      ...log
+      from,
+      to,
+      mail_template_id,
+      owner,
+      category_no
     })
   );
 };
@@ -77,30 +85,33 @@ const insertMailToDB = async content => {
   const receivers = getReceivers(mail);
   const connection = await pool.getConnection(async conn => conn);
   let queryFormat;
-  const log = {};
 
   try {
     await connection.beginTransaction();
     queryFormat = format.getQueryToAddMailTemplate(mail);
     const [{ insertId }] = await connection.execute(queryFormat);
 
-    for await (let attachment of mail.attachments) {
+    const insertingAttachments = mail.attachments.map(async attachment => {
+      const result = await multipartUpload(attachment);
+      attachment.url = result.key;
       attachment.mail_template_id = insertId;
       queryFormat = format.getQueryToAddAttachment(attachment);
-      await connection.execute(queryFormat);
-    }
+      return connection.execute(queryFormat);
+    });
 
-    for await (let id of receivers) {
+    const insertingMails = receivers.map(async id => {
       queryFormat = format.getQueryToFindOwnerAndCategoryNo(id);
       const [[{ owner, no }]] = await connection.query(queryFormat);
-      log.mail_template_id = insertId;
-      log.owner = owner;
-      log.category_no = no;
-      queryFormat = format.getQueryToAddMail(log);
-      await connection.execute(queryFormat);
-      recordLog(mail, log);
-    }
+      mail.mail_template_id = insertId;
+      mail.owner = owner;
+      mail.category_no = no;
+      queryFormat = format.getQueryToAddMail(mail);
+      recordLog(mail);
+      return connection.execute(queryFormat);
+    });
 
+    await Promise.all(insertingAttachments);
+    await Promise.all(insertingMails);
     await connection.commit();
     connection.release();
   } catch (err) {

--- a/infra/maildb/src/app.js
+++ b/infra/maildb/src/app.js
@@ -39,7 +39,7 @@ const parseMailContent = async content => {
       from: from.text,
       to: to.text,
       subject: subject || UNTITLE,
-      text: text || html,
+      text: html || text,
       attachments,
       headers
     };

--- a/infra/maildb/src/env.js
+++ b/infra/maildb/src/env.js
@@ -1,0 +1,11 @@
+module.exports = {
+  DB_DEV_USERNAME: "",
+  DB_DEV_PW: "",
+  DB_DEV_SCHEMA: "",
+  DB_DEV_HOST: "",
+  STORAGE_END_POINT: "",
+  STORAGE_REGION: "",
+  STORAGE_BUCKET: "",
+  STORAGE_ACCESS_KEY: "",
+  STORAGE_SECRET_KEY: ""
+};

--- a/infra/maildb/src/format.js
+++ b/infra/maildb/src/format.js
@@ -42,15 +42,17 @@ const getQueryToAddMailTemplate = ({ from, to, subject, text }) => {
 
 const getQueryToAddAttachment = ({
   filename,
-  content,
+  url,
   contentType,
-  mail_template_id
+  mail_template_id,
+  size
 }) => {
   const valueOfAttachment = {
     name: filename,
-    content,
+    url,
     type: contentType,
-    mail_template_id
+    mail_template_id,
+    size
   };
   return mysql.format(QUERY.INSERT, [TABLE.ATTACHMENT, valueOfAttachment]);
 };

--- a/infra/maildb/src/format.js
+++ b/infra/maildb/src/format.js
@@ -72,13 +72,19 @@ const getQueryToFindOwnerAndCategoryNo = id => {
   ]);
 };
 
-const getQueryToAddMail = ({ owner, category_no, mail_template_id }) => {
+const getQueryToAddMail = ({
+  owner,
+  category_no,
+  mail_template_id,
+  message_id
+}) => {
   const valueOfMail = {
     owner,
     category_no,
     mail_template_id,
     is_important: 0,
-    is_read: 0
+    is_read: 0,
+    message_id
   };
 
   return mysql.format(QUERY.INSERT, [TABLE.MAIL, valueOfMail]);

--- a/infra/maildb/src/ncloud.js
+++ b/infra/maildb/src/ncloud.js
@@ -1,0 +1,55 @@
+const uuidv4 = require("uuid");
+const AWS = require("aws-sdk");
+
+const {
+  STORAGE_END_POINT,
+  STORAGE_REGION,
+  STORAGE_ACCESS_KEY,
+  STORAGE_SECRET_KEY,
+  STORAGE_BUCKET
+} = require("./env");
+
+const MB = 1024 * 1024;
+const FILE_LIMIT_SIZE = 10 * MB;
+
+const endpoint = new AWS.Endpoint(STORAGE_END_POINT);
+const region = STORAGE_REGION;
+
+AWS.config.update({
+  accessKeyId: STORAGE_ACCESS_KEY,
+  secretAccessKey: STORAGE_SECRET_KEY
+});
+
+const BASE_PATH = "mail/";
+const S3 = new AWS.S3({
+  endpoint,
+  region
+});
+
+const options = {
+  partSize: FILE_LIMIT_SIZE
+};
+
+const rename = originalname => {
+  const splitedFileName = originalname.split(".");
+  const now = Date.now();
+  const fileName = now + uuidv4().replace(/-/g, "");
+  const extension = splitedFileName[splitedFileName.length - 1];
+  const newFileName = `${fileName}.${extension}`;
+  return newFileName;
+};
+
+const multipartUpload = ({ content, filename }) => {
+  const newName = rename(filename);
+  const promise = S3.upload(
+    {
+      Bucket: STORAGE_BUCKET,
+      Key: BASE_PATH + newName,
+      Body: content
+    },
+    options
+  ).promise();
+  return promise;
+};
+
+module.exports = { multipartUpload };


### PR DESCRIPTION
### 무엇을 (What)
1. 메일 수신 시 ncloud object storage 저장하고 반환한 url값을 attahcment DB에 저장
2. env.js 추가

### 왜 그 방법을 선택했는가? (Why)
1. 수신한 메일의 첨부파일도 우리 서버에서 관리해야하고 DB에는 buffer가 아닌 url을 저장하기 때문
2. 기존에는 node-runner에서 설정값들을 넘겨받았지만 ncloud.js 파일도 추가되면서 이 방법이 불편하다고 느낌. 그래서 env.js 파일을 새로 만듦. 보안을 위해 value들은 "" 처리하였음.

### 리뷰어 참고사항
.txt .jpg 는 수신할 때 postfix hook이 발생하는 것을 확인하였지만, png는 hook이 발생하지 않음. 추후 whitelist에 추가만하면 해결될 듯 하다.
