### PR TITLE
[BE] 예약 메일 전송 API - 첨부 파일 전송

### DIFF
--- a/server/src/v1/admin/mail/service.js
+++ b/server/src/v1/admin/mail/service.js
@@ -7,21 +7,37 @@ import { aesDecrypt } from '../../../libraries/crypto';
 import U from '../../../libraries/mail-util';
 import { makeMimeMessage } from '../../../libraries/mimemessage';
 import { saveToMailbox } from '../../../libraries/save-to-infra';
+import { getStream } from '../../../libraries/storage/ncloud';
 
 const ALLOWED_TIME = 10;
 
 const SENT_MAILBOX_NAME = '보낸메일함';
 
+const getFileNameAndBufferFromAttachment = async ({ url, name }) => {
+  const stream = getStream(url);
+
+  const buffer = await new Promise(resolve => {
+    stream.on('data', data => {
+      resolve(data);
+    });
+  });
+
+  return { buffer, originalname: name };
+};
+
 const sendResrvationMail = async mail => {
   const { owner, MailTemplate, reservation_time } = mail;
-  const { from, to, subject, text } = MailTemplate;
+  const { from, to, subject, text, Attachments } = MailTemplate;
   const mailboxName = SENT_MAILBOX_NAME;
 
   const user = await DB.User.findByPk(owner, { raw: true });
   user.password = aesDecrypt(user.imap_password);
 
   const transporter = nodemailer.createTransport(U.getTransport(user));
-  const mailContents = U.getSingleMailData({ from, to, subject, text });
+  const promises = Attachments.map(attachment => getFileNameAndBufferFromAttachment(attachment));
+  const attachments = await Promise.all(promises);
+
+  const mailContents = U.getSingleMailData({ from, to, subject, text, attachments });
   mailContents.date = reservation_time;
 
   const { messageId } = await transporter.sendMail(mailContents);


### PR DESCRIPTION
### 무엇을 (What)
1. 메일 예약 전송시 attachment를 object storage로 부터 파일을 받아와서 첨부하여 함께 전송

### 왜 그 방법을 선택했는가? (Why)
1. 예약 메일 등록시 attachment 같은 경우는 object storage에 저장하도록 함. 따라서 예약 전송시 object storage의 attachment를 받아와 전송하도록 함

### 리뷰어 참고사항
[Stream으로 부터 데이터를 받아오는 방법](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html#createReadStream-property)
