### PR TITLE
[BE] 회원가입시 이름 정규식 특수문자 확인 못하는 문제 해결

### DIFF
--- a/server/src/database/models/user.js
+++ b/server/src/database/models/user.js
@@ -51,13 +51,13 @@ const model = (sequelize, DataTypes) => {
         type: DataTypes.STRING(255),
         allowNull: false,
         validate: {
-          is: {
-            args: /[a-zA-Z가-힣 ]/,
-            msg: '이름의 형식이 올바르지 않습니다.',
-          },
           len: {
             args: [1, 10],
             msg: '이름의 길이는 1이상 10이하 이어야 합니다.',
+          },
+          is: {
+            args: /^[a-zA-Z가-힣 ]{1,10}$/,
+            msg: '이름의 형식이 올바르지 않습니다.',
           },
         },
       },

--- a/server/test/user/database.spec.js
+++ b/server/test/user/database.spec.js
@@ -97,6 +97,20 @@ describe('User DB Test..', () => {
         error.path.should.be.equals('name');
         error.value.should.be.equals(name);
       });
+
+      it('# name에 특수문자가 포함될 경우 이름의 형식이 올바르지 않습니다.를 반환한다.', async () => {
+        const name = '가;;;;;';
+        const data = await DB.User.build({
+          ...user,
+          name,
+        })
+          .validate()
+          .should.be.rejected();
+        const error = data.errors[0];
+        error.message.should.be.equals('이름의 형식이 올바르지 않습니다.');
+        error.path.should.be.equals('name');
+        error.value.should.be.equals(name);
+      });
     });
 
     describe('password validate는...', () => {


### PR DESCRIPTION
### 무엇을 (What)
1. 회원가입시 이름에 특수문자가 포함되어 있어도 정규식으로 걸러내지 못 하는 문제 해결

### 왜 그 방법을 선택했는가? (Why)
1. 정규식으로 이름 형식을 확인하는데 길이를 넣지 않을 경우 정규식이 제대로 특수문자를 걸러내지 않아서 길이를 넣음

### 리뷰어 참고사항
1. validate의 "len" 필드를 "is" 필드를 위로 올릴 경우 "len" 부터 조건에 맞는지 확인 후 "is"의 정규식이 조건에 맞는지 확인함. 순서를 보장하는 것 같음.

	![](https://i.imgur.com/z12LvZI.png)
