### PR TITLE
[홍종화]w5_리뷰요청_프론트에러처리&파일다운로드

### DIFF
--- a/review/be/libraries/storage/ncloud.js
+++ b/review/be/libraries/storage/ncloud.js
@@ -1,0 +1,76 @@
+/* eslint-disable object-curly-newline */
+import uuidv4 from 'uuid';
+import AWS from 'aws-sdk';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const MB = 1024 * 1024;
+const FILE_LIMIT_SIZE = 10 * MB;
+
+const {
+  STORAGE_END_POINT,
+  STORAGE_REGION,
+  STORAGE_ACCESS_KEY,
+  STORAGE_SECRET_KEY,
+  STORAGE_BUCKET,
+} = process.env;
+
+const endpoint = new AWS.Endpoint(STORAGE_END_POINT);
+const region = STORAGE_REGION;
+
+AWS.config.update({
+  accessKeyId: STORAGE_ACCESS_KEY,
+  secretAccessKey: STORAGE_SECRET_KEY,
+});
+
+const BASE_PATH = 'mail/';
+const S3 = new AWS.S3({
+  endpoint,
+  region,
+});
+
+const options = {
+  partSize: FILE_LIMIT_SIZE,
+};
+
+const rename = originalname => {
+  const splitedFileName = originalname.split('.');
+  const now = Date.now();
+  const fileName = now + uuidv4().replace(/-/g, '');
+  const extension = splitedFileName[splitedFileName.length - 1];
+  const newFileName = `${fileName}.${extension}`;
+  return newFileName;
+};
+
+const multipartUpload = ({ buffer, originalname }) => {
+  const newName = rename(originalname);
+  const promise = S3.upload(
+    {
+      Bucket: STORAGE_BUCKET,
+      Key: BASE_PATH + newName,
+      Body: buffer,
+    },
+    options,
+  ).promise();
+  return promise;
+};
+
+const download = path => {
+  const file = S3.getObject({
+    Bucket: STORAGE_BUCKET,
+    Key: path,
+  }).promise();
+
+  return file;
+};
+
+const getStream = path => {
+  const stream = S3.getObject({
+    Bucket: STORAGE_BUCKET,
+    Key: path,
+  }).createReadStream();
+  return stream;
+};
+
+export { download, multipartUpload, getStream };

--- a/review/be/v1/mail/attachment/controller.js
+++ b/review/be/v1/mail/attachment/controller.js
@@ -1,0 +1,39 @@
+import service from './service';
+import validateNo from '../../../libraries/validation/mail-template';
+
+const downloadAttachment = async (req, res, next) => {
+  const { no } = req.params;
+  const { email } = req.user;
+
+  let attachment;
+  try {
+    validateNo(no);
+    attachment = await service.getAttachment({ attachmentNo: no, email });
+  } catch (error) {
+    return next(error);
+  }
+
+  return res.end(attachment.Body);
+};
+
+const previewAttachment = async (req, res, next) => {
+  const { no } = req.params;
+  const { email } = req.user;
+
+  let streamAndMimetype;
+  try {
+    validateNo(no);
+    streamAndMimetype = await service.getAttachmentStream({ attachmentNo: no, email });
+  } catch (error) {
+    return next(error);
+  }
+
+  const { mimetype } = streamAndMimetype;
+  res.setHeader('Content-type', mimetype);
+  return streamAndMimetype.pipe(res);
+};
+
+export default {
+  downloadAttachment,
+  previewAttachment,
+};

--- a/review/be/v1/mail/attachment/index.js
+++ b/review/be/v1/mail/attachment/index.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import controller from './controller';
+
+const router = Router();
+
+router.get('/:no/download', controller.downloadAttachment);
+router.get('/:no/preview', controller.previewAttachment);
+
+export default router;

--- a/review/be/v1/mail/attachment/service.js
+++ b/review/be/v1/mail/attachment/service.js
@@ -1,0 +1,60 @@
+import DB from '../../../database';
+import ERROR_CODE from '../../../libraries/exception/error-code';
+import ErrorResponse from '../../../libraries/exception/error-response';
+import { download, getStream } from '../../../libraries/storage/ncloud';
+
+const getAttachment = async ({ attachmentNo, email }) => {
+  const mailTemplateAndAttachment = await DB.Attachment.findAttachmentAndMailTemplateByPk(
+    attachmentNo,
+  );
+
+  if (!mailTemplateAndAttachment) {
+    throw new ErrorResponse(ERROR_CODE.PAGE_NOT_FOUND);
+  }
+
+  const to = mailTemplateAndAttachment['MailTemplate.to'];
+  const from = mailTemplateAndAttachment['MailTemplate.from'];
+  const tos = to.split(',').map(user => user.trim());
+  const accessibleUsers = [from, ...tos];
+
+  if (!accessibleUsers.some(user => user === email)) {
+    throw new ErrorResponse(ERROR_CODE.PRIVATE_PATH);
+  }
+
+  const file = await download(mailTemplateAndAttachment.url);
+  file.mimetype = mailTemplateAndAttachment.type;
+  return file;
+};
+
+const getAttachmentStream = async ({ attachmentNo, email }) => {
+  const mailTemplateAndAttachment = await DB.Attachment.findAttachmentAndMailTemplateByPk(
+    attachmentNo,
+  );
+
+  if (!mailTemplateAndAttachment) {
+    throw new ErrorResponse(ERROR_CODE.PAGE_NOT_FOUND);
+  }
+
+  const to = mailTemplateAndAttachment['MailTemplate.to'];
+  const from = mailTemplateAndAttachment['MailTemplate.from'];
+  const tos = to.split(',').map(user => user.trim());
+  const accessibleUsers = [from, ...tos];
+
+  if (!accessibleUsers.some(user => user === email)) {
+    throw new ErrorResponse(ERROR_CODE.PRIVATE_PATH);
+  }
+
+  const isImage = mailTemplateAndAttachment.type.split('/')[0] === 'image';
+  if (!isImage) {
+    throw new ErrorResponse(ERROR_CODE.NOT_ALLOWED_PREVIEW_EXTENSION);
+  }
+
+  const stream = await getStream(mailTemplateAndAttachment.url);
+  stream.mimetype = mailTemplateAndAttachment.type;
+  return stream;
+};
+
+export default {
+  getAttachment,
+  getAttachmentStream,
+};

--- a/review/be/v1/mail/index.js
+++ b/review/be/v1/mail/index.js
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import multer from 'multer';
+import controller from './controller';
+import mailBox from './box';
+import mailTemplate from './template';
+import attachment from './attachment';
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+const { MAIL_FILE_MAX_COUNT } = process.env;
+
+router.get('/', controller.list);
+router.get('/categories', controller.getCategories);
+router.patch('/:no', controller.update);
+router.post('/', upload.array('attachments', MAIL_FILE_MAX_COUNT), controller.write);
+
+router.use('/box', mailBox);
+router.use('/template', mailTemplate);
+router.use('/attachment', attachment);
+
+export default router;

--- a/review/fe/components/Error/Server/index.js
+++ b/review/fe/components/Error/Server/index.js
@@ -1,0 +1,16 @@
+import React from "react";
+import S from "./styled";
+import * as GS from "../../GlobalStyle";
+import fixImage from "../../../public/fix.png";
+
+const ServerError = ({ message }) => {
+  return (
+    <GS.FlexCenterWrap>
+      <S.FixImage src={fixImage} alt="fix image" />
+      <p>죄송합니다. 신속히 고치겠습니다.</p>
+      <p>{message}</p>
+    </GS.FlexCenterWrap>
+  );
+};
+
+export default ServerError;

--- a/review/fe/components/Error/User/index.js
+++ b/review/fe/components/Error/User/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import * as GS from "../../GlobalStyle";
+
+const UserError = ({ message }) => {
+  return (
+    <GS.FlexCenterWrap>
+      <p>{message}</p>
+    </GS.FlexCenterWrap>
+  );
+};
+
+export default UserError;

--- a/review/fe/components/MailArea/index.js
+++ b/review/fe/components/MailArea/index.js
@@ -1,0 +1,98 @@
+/* eslint-disable camelcase */
+import React, { useState, useContext, useMemo } from 'react';
+import MailTemplate from './MailTemplate';
+import S from './styled';
+import Paging from './Paging';
+import { AppDispatchContext, AppStateContext } from '../../contexts';
+import Loading from '../Loading';
+import {
+  handleMailClick,
+  handleMailsChange,
+  initCheckerInTools,
+  handleSnackbarState,
+} from '../../contexts/reducer';
+import useFetch from '../../../utils/use-fetch';
+import getQueryByOptions from '../../utils/query';
+import Tools from './Tools';
+import ReadMail from '../ReadMail';
+import request from '../../../utils/request';
+import { getSnackbarState, SNACKBAR_VARIANT } from '../Snackbar';
+import noMailImage from '../../assets/imgs/no-mail.png';
+import errorHandler from '../../../utils/error-handler';
+
+const WASTEBASKET_NAME = '휴지통';
+
+const ACTION = {
+  STAR: 'star',
+  DELETE: 'delete',
+  READ: 'read',
+};
+
+const SNACKBAR_MSG = {
+  ERROR: {
+    DELETE: '메일 삭제를 실패하였습니다.',
+    STAR: '메일 중요표시에 실패하였습니다.',
+    UNSTAR: '메일 중요표시 해제에 실패하였습니다.',
+    LOAD: '메일 불러오기에 실패하였습니다.',
+  },
+  SUCCESS: {
+    DELETE: '메일을 삭제하였습니다.',
+    STAR: '메일 중요표시를 하였습니다.',
+    UNSTAR: '메일 중요표시를 해제하였습니다.',
+  },
+};
+
+const convertMailToRead = mail => {
+  const { is_important, is_read, MailTemplate, no, reservation_time } = mail;
+  const { from, to, subject, text, html, createdAt, no: mailTemplateNo } = MailTemplate;
+  return {
+    from,
+    to,
+    subject: subject || '제목없음',
+    text,
+    html,
+    createdAt,
+    is_important,
+    is_read,
+    no,
+    mailTemplateNo,
+    reservation_time,
+  };
+};
+
+const loadNewMails = async (query, dispatch) => {
+  const { isError, data } = await request.get(`/mail/?${query}`);
+  if (isError) {
+    throw SNACKBAR_MSG.ERROR.LOAD;
+  }
+  dispatch(handleMailsChange({ ...data }));
+};
+
+const updateMail = async (no, props) => {
+  return request.patch(`/mail/${no}`, { props });
+};
+
+const MailArea = () => {
+  const { state } = useContext(AppStateContext);
+  const { dispatch } = useContext(AppDispatchContext);
+  const query = getQueryByOptions(state);
+  const URL = `/mail?${query}`;
+  const fetchingMailData = useFetch(URL);
+
+  useMemo(() => {
+    dispatch(initCheckerInTools());
+    dispatch(handleMailsChange({ ...fetchingMailData.data }));
+  }, [dispatch, fetchingMailData.data]);
+
+  if (fetchingMailData.loading || !state.mails) {
+    return <Loading />;
+  }
+
+  if (fetchingMailData.error) {
+    return errorHandler(fetchingMailData.error);
+  }
+
+  // 랜더링 로직 생략
+};
+
+export default MailArea;

--- a/review/fe/components/ReadMail/FileList/index.js
+++ b/review/fe/components/ReadMail/FileList/index.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import AttachFileIcon from '@material-ui/icons/AttachFile';
+import { List, ListItem, Tooltip } from '@material-ui/core';
+import fileDownload from 'js-file-download';
+import prettyBytes from 'pretty-bytes';
+import * as GS from '../../GlobalStyle';
+import * as S from './styled';
+import request from '../../../utils/request';
+
+const API_SERVER = 'http://localhost';
+
+const FileList = ({ files }) => {
+  const imageList = [];
+  const fileList = files.map(file => {
+    const isImage = file.type.split('/')[0] === 'image';
+    const src = `${API_SERVER}/mail/attachment/${file.no}/preview`;
+    if (isImage) {
+      imageList.push(
+        <S.ImageColumn key={`image${file.no}`}>
+          <S.ImageWrapper onClick={() => window.open(src, '_blank')}>
+            <S.Image src={src} alt={file.name} />
+          </S.ImageWrapper>
+          <S.ImageName id={file.no}>{file.name}</S.ImageName>
+        </S.ImageColumn>,
+      );
+    }
+    return (
+      <Tooltip key={file.no} title={prettyBytes(file.size)} placement='right' open={true}>
+        <ListItem
+          style={{
+            display: 'block',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          button
+          id={file.no}>
+          {file.name}
+        </ListItem>
+      </Tooltip>
+    );
+  });
+
+  const handleDownloadClick = async e => {
+    e.preventDefault();
+    let { id, innerText } = e.target;
+    if (!id || id === '') {
+      return;
+    }
+
+    id = Number(id);
+    if (!Number.isInteger(id)) {
+      return;
+    }
+
+    const { isError, data } = await request.get(`/mail/attachment/${id}/download`, {
+      responseType: 'arraybuffer',
+    });
+
+    if (isError) {
+      return;
+    }
+    fileDownload(data, innerText);
+  };
+
+  const { length } = fileList;
+  return (
+    <GS.FlexColumnWrap onClick={handleDownloadClick}>
+      <S.FlexColumnHeader>
+        <AttachFileIcon />
+        첨부파일 {length}개
+      </S.FlexColumnHeader>
+      <List style={{ width: '300px' }}>{fileList}</List>
+      <S.ImageGrid>{imageList}</S.ImageGrid>
+    </GS.FlexColumnWrap>
+  );
+};
+
+export default FileList;

--- a/review/fe/utils/error-handler.js
+++ b/review/fe/utils/error-handler.js
@@ -1,0 +1,20 @@
+import React from "react";
+import Router from "next/router";
+import UserError from "../components/Error/User";
+import ServerError from "../components/Error/Server";
+
+const handleErrorStatus = ({ status, message }) => {
+  let returnValue = "";
+
+  if (status === 401) {
+    Router.push("/login");
+  } else if (status >= 400 && status < 500) {
+    returnValue = <UserError message={message} />;
+  } else if (status >= 500) {
+    returnValue = <ServerError message={message} />;
+  }
+
+  return returnValue;
+};
+
+export default handleErrorStatus;

--- a/review/fe/utils/error-parser.js
+++ b/review/fe/utils/error-parser.js
@@ -1,0 +1,26 @@
+const isContainedErrorCode = error => {
+  const { response } = error;
+  return response && response.data && response.data.errorCode;
+};
+
+const errorParser = error => {
+  if (!isContainedErrorCode(error)) {
+    return { status: 500, message: error.message };
+  }
+
+  const { errorCode, fieldErrors } = error.response.data;
+
+  const { status, message } = errorCode;
+  if (status !== 400) {
+    return { status, message };
+  }
+
+  const errorMessage = fieldErrors.reduce((prev, next) => {
+    const line = `${next.field} : ${next.reason}\n`;
+    return prev + line;
+  }, "");
+
+  return { status: 400, message: errorMessage };
+};
+
+export { errorParser };

--- a/review/fe/utils/http-response.js
+++ b/review/fe/utils/http-response.js
@@ -1,0 +1,7 @@
+class HTTPResponse {
+  constructor(isError, data) {
+    this.isError = isError;
+    this.data = data;
+  }
+}
+export default HTTPResponse;

--- a/review/fe/utils/request.js
+++ b/review/fe/utils/request.js
@@ -1,0 +1,59 @@
+import axios from "axios";
+import { errorParser } from "./error-parser";
+import HTTPResponse from "./http-response";
+
+const execute = async fn => {
+  let response;
+
+  try {
+    const { data } = await fn();
+    response = new HTTPResponse(false, data);
+  } catch (err) {
+    const error = errorParser(err);
+    response = new HTTPResponse(true, error);
+  }
+  return response;
+};
+
+axios.defaults.withCredentials = true;
+
+const server = axios.create({
+  baseURL: "http://localhost/",
+  timeout: 5000,
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json; charset=utf-8"
+  }
+});
+
+export default {
+  async get(url, options = {}) {
+    const fn = () => server.get(url, { ...options });
+    const response = await execute(fn);
+    return response;
+  },
+
+  async post(url, body, options = {}) {
+    const fn = () => server.post(url, body, { ...options });
+    const response = await execute(fn);
+    return response;
+  },
+
+  async put(url, body, options = {}) {
+    const fn = () => server.put(url, body, { ...options });
+    const response = await execute(fn);
+    return response;
+  },
+
+  async delete(url, options = {}) {
+    const fn = () => server.delete(url, { ...options });
+    const response = await execute(fn);
+    return response;
+  },
+
+  async patch(url, body, options = {}) {
+    const fn = () => server.patch(url, body, { ...options });
+    const response = await execute(fn);
+    return response;
+  }
+};

--- a/review/fe/utils/use-fetch.js
+++ b/review/fe/utils/use-fetch.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+import request from "./request";
+
+const initialValues = { loading: true, error: false, data: null };
+
+const useFetch = URL => {
+  const [fetchingData, setFetchingData] = useState(initialValues);
+
+  useEffect(() => {
+    const fetchInitData = async () => {
+      setFetchingData(initialValues);
+
+      const { isError, data } = await request.get(URL);
+      if (isError) {
+        setFetchingData({ loading: false, error: data, data: null });
+      } else {
+        setFetchingData({ loading: false, error: null, data });
+      }
+    };
+
+    fetchInitData(URL);
+  }, [URL]);
+
+  return fetchingData;
+};
+
+export default useFetch;


### PR DESCRIPTION
안녕하세요. 리뷰어님.

이번 주는 FE 에러 처리와 파일 다운로드를 담당했습니다.
FE 에러 처리는 지난주에 진행했었고, 이전 리뷰어님이 첨삭해준 것을 기반하여 수정했습니다.
[w4_리뷰요청_프론트_에러처리](https://github.com/connect-foundation/2019-06/pull/220)

## 질문사항

### 에러처리
1. useFetch에서 데이터를 가져온 뒤, 이 데이터를 context에 넣어줘야 해서 dispatch를 발동시킵니다. 이때, context가 변해서 계속해서 리랜더링 되는 현상이 발생했습니다. 때문에 이를 useEffect나 useMemo를 통해 해결하려 했습니다. useFetch에서도 useEffect를 사용하는 데 이를 또 useEffect를 사용하는 것이 이상하다는 팀원의 피드백과 [useMemo vs useEffect](https://stackoverflow.com/questions/56028913/usememo-vs-useEffect-usestate)의 글을 보고 useMemo가 더 적절해 보인다고 판단해서 useMemo를 사용했습니다. ( useEffect를 사용한 경우 이전화면이 전부 렌더링 될때까지 대기해서, 원치 않은 화면의 잔상이 남아있는 경우가 존재함)
이것이 적절한 판단인지 궁금합니다.

리뷰를 올리고 useMemo 문서를 살펴보니, side effect를 useMemo로 해결하지 말라는 글이 있네요. useEffect가 맞을것 같다는 생각이 드네요..

2. useMemo와 useEffect의 차이점을 아직까지 명확하게 알지 못하고 있는 상태입니다. 어떤 관점에서 바라봐야 하는지 궁금합니다.

3. status 코드별 다른 동작을 할 수 있도록 error-handler를 만들었습니다. 리뷰어님께서는 어떻게 에러 처리를 하고 있는지 궁금합니다.

### 파일 다운로드
1. 파일 다운로드를 요청했을 때, 다운로드의 정도를 percent로 보여주고 싶은데 방법을 모르겠습니다.
현재는 서버에서 storage에서 전부 다운로드하고 이를 전달하는 방식으로 사용하고 있는데. 이를 개선하고 싶습니다.