### PR TITLE
[성재호]w5_리뷰요청_팀원이_함께_사용할_알림바/메일쓰기_내부에서_사용하는_토글버튼

### DIFF
--- a/review_w5/MessageSnackbar/index.js
+++ b/review_w5/MessageSnackbar/index.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Snackbar } from '@material-ui/core';
+import MessageSnackbarContentWrapper from './content';
+
+/**
+ * top - center에 등장하는 snackbar
+ * @param {Object} snackbar - snackbar를 위한 { state, setState } Object
+ * @param {Boolean} snackbar.snackbarOpen
+ * @param {String} snackbar.snackbarVariant - 'error' || 'success' || 'info'
+ * @param {String} snackbar.snackbarContent - snackbar에 넣을 text
+ * @param {Function} snackbar.snackbarClose - 스낵바를 받아줄 close 함수를 넣어주세요
+ * @param {Number} snackbar.autoHideDuration - 자동 닫힘 시간 (단위 - ms) default: 5000
+ */
+const MessageSnackbar = ({
+  snackbarOpen,
+  snackbarVariant,
+  snackbarContent,
+  snackbarClose,
+  autoHideDuration = 5000,
+}) => {
+  return (
+    <Snackbar
+      anchorOrigin={{
+        vertical: 'top',
+        horizontal: 'center',
+      }}
+      open={snackbarOpen}
+      autoHideDuration={autoHideDuration}
+      onClose={snackbarClose}>
+      <MessageSnackbarContentWrapper
+        onClose={snackbarClose}
+        variant={snackbarVariant}
+        message={snackbarContent}
+      />
+    </Snackbar>
+  );
+};
+
+export const snackbarInitState = {
+  snackbarOpen: false,
+  snackbarVariant: 'error',
+  snackbarContent: '',
+  snackbarClose: null,
+};
+
+export const SNACKBAR_VARIANT = {
+  ERROR: 'error',
+  SUCCESS: 'success',
+  INFO: 'info',
+};
+
+export const getSnackbarState = (variant, contentText) => {
+  return {
+    snackbarOpen: true,
+    snackbarVariant: variant,
+    snackbarContent: contentText,
+  };
+};
+
+export default MessageSnackbar;

--- a/review_w5/WriteMail/Tools/ChangeWriteAreaButton/index.js
+++ b/review_w5/WriteMail/Tools/ChangeWriteAreaButton/index.js
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+import { Button } from '@material-ui/core';
+import { Loop as LoopIcon } from '@material-ui/icons';
+import { setView } from '../../../../contexts/reducer';
+import { AppDispatchContext } from '../../../../contexts';
+import WriteMail from '../../../WriteMail';
+import WriteMailToMe from '../../../WriteMailToMe';
+
+const ChangeWriteAreaButton = ({ writeToMe }) => {
+  const { dispatch } = useContext(AppDispatchContext);
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={() => dispatch(setView(writeToMe ? <WriteMail /> : <WriteMailToMe />))}>
+      <LoopIcon fontSize="small" />
+      {writeToMe ? '편지쓰기' : '내게쓰기'}
+    </Button>
+  );
+};
+
+export default ChangeWriteAreaButton;

--- a/review_w5/WriteMail/Tools/SwitchDropzone/index.js
+++ b/review_w5/WriteMail/Tools/SwitchDropzone/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+
+const SwitchDropzone = ({ dropZoneVisible, setDropZoneVisible }) => (
+  <Button
+    variant="outlined"
+    style={{ marginLeft: '10px' }}
+    onClick={() => setDropZoneVisible(!dropZoneVisible)}>
+    {dropZoneVisible ? '첨부파일 닫기' : '첨부파일 열기'}
+  </Button>
+);
+
+export default SwitchDropzone;

--- a/review_w5/WriteMail/Tools/index.js
+++ b/review_w5/WriteMail/Tools/index.js
@@ -1,0 +1,178 @@
+import React, { useState, useContext } from 'react';
+import { Send as SendIcon, ArrowDropDown as ArrowDropDownIcon } from '@material-ui/icons';
+import {
+  Button,
+  ButtonGroup,
+  ClickAwayListener,
+  Paper,
+  Popper,
+  MenuList,
+  MenuItem,
+  Grow,
+} from '@material-ui/core';
+import * as WM_S from '../styled';
+import * as S from './styled';
+import { transformDateToReserve } from '../../../utils/transform-date';
+import { ERROR_CANNOT_RESERVATION } from '../../../utils/error-message';
+import { useStateForWM } from '../ContextProvider';
+import { AppDispatchContext } from '../../../contexts';
+import { handleCategoryClick, handleSnackbarState } from '../../../contexts/reducer';
+import MailArea from '../../MailArea';
+import ChangeWriteAreaButton from './ChangeWriteAreaButton';
+import SwitchDropzone from './SwitchDropzone';
+import validator from '../../../utils/validator';
+import { errorParser } from '../../../utils/error-parser';
+import request from '../../../utils/request';
+import ReservationTimePicker from '../ReservationTimePicker';
+import ReservationDateText from '../ReservationDateText';
+import { SNACKBAR_VARIANT, getSnackbarState } from '../../Snackbar';
+
+const SNACKBAR_MSG = {
+  ERROR: {
+    AFTER_DATE: ERROR_CANNOT_RESERVATION,
+    EMAIL_VALIDATION: '이메일 형식이 올바르지 않은 것이 존재합니다.',
+    INPUT_RECEIVERS: '받는 이메일을 입력해주세요.',
+  },
+  SUCCESS: {
+    SEND: '메일이 성공적으로 전송되었습니다.',
+  },
+  WAITING: {
+    SENDING: '전송중입니다.',
+  },
+};
+
+const Tools = ({ writeToMe, dropZoneVisible, setDropZoneVisible }) => {
+  const { receivers, files, subject, html, text, date } = useStateForWM();
+  const { dispatch: pageDispatch } = useContext(AppDispatchContext);
+  const [open, setOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const anchorRef = React.useRef(null);
+
+  const handleClick = async () => {
+    if (receivers.length === 0) {
+      pageDispatch(
+        handleSnackbarState(
+          getSnackbarState(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.INPUT_RECEIVERS),
+        ),
+      );
+      return;
+    }
+
+    if (!receivers.every(receiver => validator.validate('email', receiver))) {
+      pageDispatch(
+        handleSnackbarState(
+          getSnackbarState(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.EMAIL_VALIDATION),
+        ),
+      );
+      return;
+    }
+
+    pageDispatch(
+      handleSnackbarState(getSnackbarState(SNACKBAR_VARIANT.INFO, SNACKBAR_MSG.WAITING.SENDING)),
+    );
+    const formData = new FormData();
+    receivers.forEach(r => {
+      formData.append('to', r);
+    });
+    formData.append('subject', subject);
+    formData.append('text', text);
+    formData.append('html', html);
+    files.forEach(f => {
+      formData.append('attachments', f);
+    });
+
+    if (date) {
+      if (!validator.isAfterDate(date)) {
+        pageDispatch(
+          handleSnackbarState(
+            getSnackbarState(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.AFTER_DATE),
+          ),
+        );
+        return;
+      }
+      formData.append('reservationTime', transformDateToReserve(date));
+    }
+
+    const { isError, data } = await request.post('/mail', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+
+    if (isError) {
+      const { message } = errorParser(data);
+      pageDispatch(handleSnackbarState(getSnackbarState(SNACKBAR_VARIANT.ERROR, message)));
+    } else {
+      pageDispatch(
+        handleSnackbarState(getSnackbarState(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.SEND)),
+      );
+      pageDispatch(handleCategoryClick(0, <MailArea />));
+    }
+  };
+
+  const handleToggle = () => {
+    setOpen(prevOpen => !prevOpen);
+  };
+
+  const handleClose = event => {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+    setOpen(false);
+  };
+
+  const handleReservationClick = () => {
+    setModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setOpen(false);
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <WM_S.RowWrapper>
+        <div></div>
+        <S.RowContainer>
+          <ButtonGroup variant="outlined" color="default" ref={anchorRef}>
+            <Button onClick={handleClick}>보내기</Button>
+            <Button color="default" size="small" onClick={handleToggle}>
+              <ArrowDropDownIcon />
+            </Button>
+          </ButtonGroup>
+          <ReservationDateText />
+          <ChangeWriteAreaButton writeToMe={writeToMe} />
+          <SwitchDropzone {...{ dropZoneVisible, setDropZoneVisible }} />
+          <Popper
+            open={open}
+            anchorEl={anchorRef.current}
+            role={undefined}
+            transition
+            disablePortal>
+            {({ TransitionProps, placement }) => (
+              <Grow
+                {...TransitionProps}
+                style={{
+                  transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
+                }}>
+                <Paper>
+                  <ClickAwayListener onClickAway={handleClose}>
+                    <MenuList id="split-button-menu">
+                      <MenuItem onClick={handleReservationClick}>
+                        <S.VerticalAlign>
+                          {<SendIcon fontSize="small" />} <span>보내기 예약</span>
+                        </S.VerticalAlign>
+                      </MenuItem>
+                    </MenuList>
+                  </ClickAwayListener>
+                </Paper>
+              </Grow>
+            )}
+          </Popper>
+        </S.RowContainer>
+      </WM_S.RowWrapper>
+      <ReservationTimePicker open={modalOpen} handleModalClose={handleModalClose} />
+    </>
+  );
+};
+
+export default Tools;

--- a/review_w5/WriteMail/index.js
+++ b/review_w5/WriteMail/index.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import dynamic from 'next/dynamic';
+import * as S from './styled';
+import InputReceiver from './InputReceiver';
+import InputSubject from './InputSubject';
+import Tools from './Tools';
+import { WriteMailContextProvider } from './ContextProvider';
+import DropZone from './DropZone';
+
+const InputBody = dynamic(import('./InputBody'), { ssr: false });
+
+const WriteMail = () => {
+  const [dropZoneVisible, setDropZoneVisible] = useState(false);
+
+  return (
+    <WriteMailContextProvider>
+      <S.WriteArea>
+        <Tools dropZoneVisible={dropZoneVisible} setDropZoneVisible={setDropZoneVisible} />
+        <InputReceiver />
+        <InputSubject />
+        <DropZone visible={dropZoneVisible} />
+        <InputBody />
+      </S.WriteArea>
+    </WriteMailContextProvider>
+  );
+};
+
+export default WriteMail;

--- a/review_w5/WriteMailToMe/index.js
+++ b/review_w5/WriteMailToMe/index.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import dynamic from 'next/dynamic';
+import * as S from '../WriteMail/styled';
+import InputReceiver from '../WriteMail/InputReceiver';
+import InputSubject from '../WriteMail/InputSubject';
+import Tools from '../WriteMail/Tools';
+import { WriteMailContextProvider } from '../WriteMail/ContextProvider';
+import DropZone from '../WriteMail/DropZone';
+import sessionStorage from '../../utils/storage';
+
+const InputBody = dynamic(import('../WriteMail/InputBody'), { ssr: false });
+
+const WriteMailToMe = () => {
+  const [dropZoneVisible, setDropZoneVisible] = useState(false);
+
+  return (
+    <WriteMailContextProvider>
+      <S.WriteArea>
+        <Tools
+          writeToMe={!!sessionStorage.getUser().email}
+          dropZoneVisible={dropZoneVisible}
+          setDropZoneVisible={setDropZoneVisible}
+        />
+        <InputReceiver defaultReceiver={sessionStorage.getUser().email} />
+        <InputSubject />
+        <DropZone visible={dropZoneVisible} />
+        <InputBody />
+      </S.WriteArea>
+    </WriteMailContextProvider>
+  );
+};
+
+export default WriteMailToMe;

--- a/review_w5/context/index.js
+++ b/review_w5/context/index.js
@@ -1,0 +1,19 @@
+import React, { useReducer, createContext } from 'react';
+import { reducer, initialState } from './reducer';
+
+const AppStateContext = createContext();
+const AppDispatchContext = createContext();
+
+const AppProvider = props => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <AppStateContext.Provider value={{ state }}>
+      <AppDispatchContext.Provider value={{ dispatch }}>
+        {props.children}
+      </AppDispatchContext.Provider>
+    </AppStateContext.Provider>
+  );
+};
+
+export { AppProvider, AppStateContext, AppDispatchContext };

--- a/review_w5/context/reducer.js
+++ b/review_w5/context/reducer.js
@@ -1,0 +1,29 @@
+const SET_SNACKBAR_STATE = 'SET_SNACKBAR_STATE';
+// ...
+
+export const initialState = {
+  // ...
+  snackbarOpen: false,
+  snackbarVariant: 'error',
+  snackbarContent: '',
+  snackbarClose: null,
+};
+
+export const handleSnackbarState = payload => {
+  return {
+    type: SET_SNACKBAR_STATE,
+    payload,
+  };
+};
+
+export const reducer = (state = initialState, action) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case SET_SNACKBAR_STATE:
+      return { ...state, ...payload };
+    // ...
+    default:
+      return { ...state };
+  }
+};

--- a/review_w5/pages/index.js
+++ b/review_w5/pages/index.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState, useContext } from 'react';
+import Router from 'next/router';
+import * as GS from '../components/GlobalStyle';
+import Aside from '../components/Aside';
+import MailArea from '../components/MailArea';
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+import Loading from '../components/Loading';
+import storage from '../utils/storage';
+import MessageSnackbar from '../components/Snackbar';
+import { AppDispatchContext, AppStateContext } from '../contexts';
+import { setView, handleSnackbarState } from '../contexts/reducer';
+
+const Home = () => {
+  const { state } = useContext(AppStateContext);
+  const { dispatch } = useContext(AppDispatchContext);
+  const [user, setUser] = useState(null);
+  const { snackbarOpen, snackbarVariant, snackbarContent } = state;
+  const snackbarState = { snackbarOpen, snackbarVariant, snackbarContent };
+
+  useEffect(() => {
+    const userData = storage.getUser();
+    if (!userData) {
+      Router.push('/login');
+    } else {
+      setUser(userData);
+      dispatch(setView(<MailArea />));
+    }
+  }, [dispatch]);
+
+  const messageSnackbarProps = {
+    ...snackbarState,
+    snackbarClose: () => dispatch(handleSnackbarState({ snackbarOpen: false })),
+  };
+
+  const indexPage = (
+    <GS.FlexWrap>
+      <Header brand={'Daitnu'} />
+      <GS.Content>
+        <MessageSnackbar {...messageSnackbarProps} />
+        <Aside />
+        {state.view}
+      </GS.Content>
+      <Footer />
+    </GS.FlexWrap>
+  );
+  return user ? indexPage : <Loading full={true} />;
+};
+
+export default Home;


### PR DESCRIPTION
## 개발상황
이번 주에는
- 알람(Snackbar) 컴포넌트 - 다른 팀원들도 함께 사용할 수 있게 만들어 보았습니다
- 메일 쓰기와 내게 쓰기 간의 토글 역할을 하는 버튼
- 파일 첨부 컴포넌트 토글 버튼
을 구현하였습니다.

## 질문
1. 현재 다른 팀원들과 함께 사용할 알람(Snackbar) 컴포넌트를 구현하였는데요.
알람 컴포넌트 내부에서 init state와 variant, 스낵바 사용 시 필요한 객체를 받기 위한 getSnackbarState도 함께 구현하여 export 해주고 있습니다.
또한 이 스낵바는 각 개별 컴포넌트 내부에서 하나씩 사용을 하다가 해당 컴포넌트가 재렌더링되거나 바뀌게 된다면 버그가 발생하여 index 페이지에서 하나만 넣어주어 사용하기 위해 전역 context에서 state를 관리해주는 방법을 사용하고 있습니다.
이 스낵바를 사용하기 위해서는 아래와 같이 사용을 해야 하는데요, 조금 더 편하게 사용하게끔 해주고 싶은데 리뷰어님께서 구현하셨더라면 어떠한 방법을 사용하셨을 것 같으신지 궁금합니다.
```js
pageDispatch(
  handleSnackbarState(
    getSnackbarState(SNACKBAR_VARIANT.INFO, SNACKBAR_MSG.WAITING.SENDING)
  )
);
```

2. 그 외에 다른 코드에서 이렇게 했다면 조금 더 읽기 쉽고 깔끔한 코드가 될 수 있을 것 같다는 생각이 드시는 곳을 지적해 주시면 감사하겠습니다.