### PR TITLE
[FE] handleAction 객체 함수 컴포넌트 외부로 분리

### DIFF
--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -72,6 +72,50 @@ const updateMail = async (no, props) => {
   return request.patch(`/mail/${no}`, { props });
 };
 
+const handleAction = {
+  [ACTION.STAR]: async (mail, dispatch) => {
+    try {
+      mail.is_important = !mail.is_important;
+      const { isError } = await updateMail(mail.no, { is_important: mail.is_important });
+      if (isError) {
+        throw mail.is_important ? SNACKBAR_MSG.ERROR.UNSTAR : SNACKBAR_MSG.ERROR.STAR;
+      }
+      dispatch(
+        handleSnackbarState(
+          getSnackbarState(
+            SNACKBAR_VARIANT.SUCCESS,
+            mail.is_important ? SNACKBAR_MSG.SUCCESS.STAR : SNACKBAR_MSG.SUCCESS.UNSTAR,
+          ),
+        ),
+      );
+    } catch (errorMessage) {
+      dispatch(handleSnackbarState(getSnackbarState(SNACKBAR_VARIANT.ERROR, errorMessage)));
+    }
+  },
+  [ACTION.DELETE]: async (mail, dispatch, query) => {
+    try {
+      const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
+      const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
+      if (isError) {
+        throw SNACKBAR_MSG.ERROR.DELETE;
+      }
+      loadNewMails(query, dispatch);
+      dispatch(
+        handleSnackbarState(
+          getSnackbarState(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE),
+        ),
+      );
+    } catch (errorMessage) {
+      dispatch(handleSnackbarState(getSnackbarState(SNACKBAR_VARIANT.ERROR, errorMessage)));
+    }
+  },
+  [ACTION.READ]: (mail, dispatch) => {
+    const mailToRead = convertMailToRead(mail);
+    dispatch(handleMailClick(mailToRead, <ReadMail />));
+    updateMail(mail.no, { is_read: true });
+  },
+};
+
 const MailArea = () => {
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
@@ -91,50 +135,6 @@ const MailArea = () => {
   if (fetchingMailData.error) {
     return errorHandler(fetchingMailData.error);
   }
-
-  const handleAction = {
-    [ACTION.STAR]: async mail => {
-      try {
-        mail.is_important = !mail.is_important;
-        const { isError } = await updateMail(mail.no, { is_important: mail.is_important });
-        if (isError) {
-          throw mail.is_important ? SNACKBAR_MSG.ERROR.UNSTAR : SNACKBAR_MSG.ERROR.STAR;
-        }
-        dispatch(
-          handleSnackbarState(
-            getSnackbarState(
-              SNACKBAR_VARIANT.SUCCESS,
-              mail.is_important ? SNACKBAR_MSG.SUCCESS.STAR : SNACKBAR_MSG.SUCCESS.UNSTAR,
-            ),
-          ),
-        );
-      } catch (errorMessage) {
-        dispatch(handleSnackbarState(getSnackbarState(SNACKBAR_VARIANT.ERROR, errorMessage)));
-      }
-    },
-    [ACTION.DELETE]: async mail => {
-      try {
-        const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
-        const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
-        if (isError) {
-          throw SNACKBAR_MSG.ERROR.DELETE;
-        }
-        loadNewMails(query, dispatch);
-        dispatch(
-          handleSnackbarState(
-            getSnackbarState(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE),
-          ),
-        );
-      } catch (errorMessage) {
-        dispatch(handleSnackbarState(getSnackbarState(SNACKBAR_VARIANT.ERROR, errorMessage)));
-      }
-    },
-    [ACTION.READ]: mail => {
-      const mailToRead = convertMailToRead(mail);
-      dispatch(handleMailClick(mailToRead, <ReadMail />));
-      updateMail(mail.no, { is_read: true });
-    },
-  };
 
   const { mails, paging, categoryNoByName } = state;
   const categories = {};
@@ -157,7 +157,7 @@ const MailArea = () => {
       </S.NothingMailView>
     );
 
-  const handleMailListAreaClick = async ({ target }) => {
+  const handleMailListAreaClick = ({ target }) => {
     if (typeof target.className === 'object') {
       target = target.parentNode;
     }
@@ -169,7 +169,7 @@ const MailArea = () => {
 
     const [action, index] = id.split('-');
     const mail = mails[index];
-    handleAction[action](mail);
+    handleAction[action](mail, dispatch, query);
   };
 
   return (


### PR DESCRIPTION

### 무엇을 (What)
1. MailArea 컴포넌트 내부에서 코드를 외부로 분리

### 왜 그 방법을 선택했는가? (Why)
1. MailArea 내부 로직이 너무 많아서 분리

### 리뷰어 참고사항
전에는 안되던데 이번엔 왜 되누
