### PR TITLE
fix(be/mail): 메일리스트 시간정렬 #313

### DIFF
--- a/server/src/v1/mail/service.js
+++ b/server/src/v1/mail/service.js
@@ -22,8 +22,8 @@ const DEFAULT_MAIL_QUERY_OPTIONS = {
 };
 
 const SORT_TYPE = {
-  datedesc: [['no', 'DESC']],
-  dateasc: [['no', 'ASC']],
+  datedesc: [[DB.MailTemplate, 'createdAt', 'DESC']],
+  dateasc: [[DB.MailTemplate, 'createdAt', 'ASC']],
   subjectdesc: [[DB.MailTemplate, 'subject', 'DESC']],
   subjectasc: [[DB.MailTemplate, 'subject', 'ASC']],
   fromdesc: [[DB.MailTemplate, 'from', 'DESC']],

--- a/server/test/libraries/mail/attachment.spec.js
+++ b/server/test/libraries/mail/attachment.spec.js
@@ -70,7 +70,6 @@ describe('attachment validation...', () => {
       try {
         checkAttachment(files);
       } catch (err) {
-        console.log(err);
         const { errorCode, fieldErrors } = err;
         errorCode.status.should.be.equals(400);
         errorCode.message.should.be.equals('INVALID INPUT VALUE');
@@ -105,7 +104,6 @@ describe('attachment validation...', () => {
       try {
         checkAttachment(files);
       } catch (err) {
-        console.log(err);
         const { errorCode, fieldErrors } = err;
         errorCode.status.should.be.equals(400);
         errorCode.message.should.be.equals('INVALID INPUT VALUE');

--- a/server/test/mail/api.spec.js
+++ b/server/test/mail/api.spec.js
@@ -192,7 +192,9 @@ describe('Mail api test...', () => {
       it('# sort가 datedesc면 받은 시간 역순으로 출력한다. ', done => {
         authenticatedUser.get('/mail?sort=datedesc').end((err, { body }) => {
           const { mails } = body;
-          mails[0].no.should.be.above(mails[1].no);
+          const mail0 = new Date(mails[0].MailTemplate.createdAt).getTime();
+          const mail1 = new Date(mails[1].MailTemplate.createdAt).getTime();
+          mail0.should.be.aboveOrEqual(mail1);
           done();
         });
       });
@@ -200,7 +202,9 @@ describe('Mail api test...', () => {
       it('# sort가 dateasc면 받은 시간순으로 출력한다. ', done => {
         authenticatedUser.get('/mail?sort=dateasc').end((err, { body }) => {
           const { mails } = body;
-          mails[0].no.should.be.below(mails[1].no);
+          const mail0 = new Date(mails[0].MailTemplate.createdAt).getTime();
+          const mail1 = new Date(mails[1].MailTemplate.createdAt).getTime();
+          mail0.should.be.belowOrEqual(mail1);
           done();
         });
       });

--- a/server/test/mail/service.spec.js
+++ b/server/test/mail/service.spec.js
@@ -78,15 +78,15 @@ describe('Mail Service Test', () => {
     it('# 매개변수 오브젝트에 sort가 dateasc면 no asc 이다...', () => {
       const query = service.getQueryByOptions({ ...data, sort: 'dateasc' });
       const order = query.order.flat();
-      order[0].should.be.equals('no');
-      order[1].should.be.equals('ASC');
+      order[1].should.be.equals('createdAt');
+      order[2].should.be.equals('ASC');
     });
 
     it('# 매개변수 오브젝트에 sort가 datedesc면 no desc 이다...', () => {
       const query = service.getQueryByOptions({ ...data, sort: 'datedesc' });
       const order = query.order.flat();
-      order[0].should.be.equals('no');
-      order[1].should.be.equals('DESC');
+      order[1].should.be.equals('createdAt');
+      order[2].should.be.equals('DESC');
     });
 
     it('# 매개변수 오브젝트에 sort가 유효한 값이 아니면 order는 존재하지 않는다...', () => {


### PR DESCRIPTION
### 무엇을 (What)
1. 메일리스트 시간정렬

### 왜 그 방법을 선택했는가? (Why)
1. no에서 createdAt으로 변경
예약기능이 들어오면서 정렬대상을 createdAt으로 수정

### 리뷰어 참고사항

