### PR TITLE
[BE] 이메일 중복 가입 처리를 위한 에러 처리

### DIFF
--- a/server/src/libraries/exception/error-code.js
+++ b/server/src/libraries/exception/error-code.js
@@ -43,7 +43,7 @@ const ERROR_CODE = {
   MAILBOX_EXCEED_NAME: $(400, '메일함 이름은 최대 20글자입니다.', 'COMMON012'),
   INVALID_DATE: $(400, '유효하지 않는 날짜 정보입니다.', 'COMMON013'),
   ID_DUPLICATION: $(409, '이미 사용중인 아이디 입니다.', 'JOIN001'),
-  EMAIL_DUPLICATION: $(409, '이미 가입에 사용한 이메일 입니다.', 'JOIN002'),
+  SUB_EMAIL_DUPLICATION: $(409, '이미 가입에 사용한 이메일 입니다.', 'JOIN002'),
 
   FAIL_TO_SEND_MAIL: $(500, '메일 전송에 실패하였습니다.', 'MAIL001'),
   FAIL_TO_SAVE_MAIL: $(500, '메일을 데이터베이스에 저장하는데 실패하였습니다.', 'MAIL002'),

--- a/server/src/libraries/exception/error-code.js
+++ b/server/src/libraries/exception/error-code.js
@@ -44,7 +44,7 @@ const ERROR_CODE = {
   INVALID_DATE: $(400, '유효하지 않는 날짜 정보입니다.', 'COMMON013'),
   ID_DUPLICATION: $(409, '이미 사용중인 아이디 입니다.', 'JOIN001'),
   SUB_EMAIL_DUPLICATION: $(409, '이미 가입에 사용한 이메일 입니다.', 'JOIN002'),
-  ID_OR_SUB_EMAIL_DUPLICATION: $(409, '아이디 혹은 이메일을 이미 사용하였습니다.', 'JOIN003'),
+  ID_AND_SUB_EMAIL_DUPLICATION: $(409, '이미 아이디와 이메일을 이미 사용하였습니다.', 'JOIN003'),
 
   FAIL_TO_SEND_MAIL: $(500, '메일 전송에 실패하였습니다.', 'MAIL001'),
   FAIL_TO_SAVE_MAIL: $(500, '메일을 데이터베이스에 저장하는데 실패하였습니다.', 'MAIL002'),

--- a/server/src/libraries/exception/error-code.js
+++ b/server/src/libraries/exception/error-code.js
@@ -44,7 +44,7 @@ const ERROR_CODE = {
   INVALID_DATE: $(400, '유효하지 않는 날짜 정보입니다.', 'COMMON013'),
   ID_DUPLICATION: $(409, '이미 사용중인 아이디 입니다.', 'JOIN001'),
   SUB_EMAIL_DUPLICATION: $(409, '이미 가입에 사용한 이메일 입니다.', 'JOIN002'),
-  ID_AND_SUB_EMAIL_DUPLICATION: $(409, '이미 아이디와 이메일을 이미 사용하였습니다.', 'JOIN003'),
+  ID_AND_SUB_EMAIL_DUPLICATION: $(409, '아이디와 이메일을 이미 사용하였습니다.', 'JOIN003'),
 
   FAIL_TO_SEND_MAIL: $(500, '메일 전송에 실패하였습니다.', 'MAIL001'),
   FAIL_TO_SAVE_MAIL: $(500, '메일을 데이터베이스에 저장하는데 실패하였습니다.', 'MAIL002'),

--- a/server/src/libraries/exception/error-code.js
+++ b/server/src/libraries/exception/error-code.js
@@ -44,6 +44,7 @@ const ERROR_CODE = {
   INVALID_DATE: $(400, '유효하지 않는 날짜 정보입니다.', 'COMMON013'),
   ID_DUPLICATION: $(409, '이미 사용중인 아이디 입니다.', 'JOIN001'),
   SUB_EMAIL_DUPLICATION: $(409, '이미 가입에 사용한 이메일 입니다.', 'JOIN002'),
+  ID_OR_SUB_EMAIL_DUPLICATION: $(409, '아이디 혹은 이메일을 이미 사용하였습니다.', 'JOIN003'),
 
   FAIL_TO_SEND_MAIL: $(500, '메일 전송에 실패하였습니다.', 'MAIL001'),
   FAIL_TO_SAVE_MAIL: $(500, '메일을 데이터베이스에 저장하는데 실패하였습니다.', 'MAIL002'),

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -2,6 +2,7 @@ import generator from 'generate-password';
 
 import DB from '../../database';
 import ErrorResponse from '../../libraries/exception/error-response';
+import ErrorField from '../../libraries/exception/error-field';
 import ERROR_CODE from '../../libraries/exception/error-code';
 import mailUtil from '../../libraries/mail-util';
 import { encrypt, aesEncrypt } from '../../libraries/crypto';
@@ -9,14 +10,39 @@ import { encrypt, aesEncrypt } from '../../libraries/crypto';
 const DEFAULT_CATEGORIES = ['받은메일함', '보낸메일함', '내게쓴메일함', '휴지통'];
 const TEMP_PASSWORD_LENGTH = 15;
 
-const isSubEmailUniqueConstraintError = error => {
+const checkSubEmailUniqueConstraintError = error => {
   if (error.errors) {
-    const [{ type, path }] = error.errors;
+    const [{ type, path, value }] = error.errors;
     if (type === 'unique violation' && path === 'sub_email') {
-      return true;
+      const errorField = new ErrorField('sub_email', value, '이미 가입에 사용한 이메일 입니다.');
+      throw new ErrorResponse(ERROR_CODE.ID_OR_SUB_EMAIL_DUPLICATION, errorField);
     }
   }
-  return false;
+  throw error;
+};
+
+const makeUniqueFieldsError = (response, userData) => {
+  const errorFields = [];
+  let errorField;
+
+  if (response.id === userData.id) {
+    errorField = new ErrorField('id', userData.id, '이미 사용중인 아이디 입니다.');
+    errorFields.push(errorField);
+  }
+  if (response.sub_email === userData.sub_email) {
+    errorField = new ErrorField(
+      'sub_email',
+      userData.sub_email,
+      '이미 가입에 사용한 이메일 입니다.',
+    );
+    errorFields.push(errorField);
+  }
+
+  if (errorFields.length > 0) {
+    throw new ErrorResponse(ERROR_CODE.ID_OR_SUB_EMAIL_DUPLICATION, errorFields);
+  }
+
+  return true;
 };
 
 const createDefaultCategories = async (no, transaction) => {
@@ -37,16 +63,13 @@ const register = async ({ id, password, name, sub_email }) => {
     await DB.sequelize.transaction(async transaction => {
       const [response, created] = await DB.User.findOrCreateById(userData, { transaction });
       if (!created) {
-        throw new ErrorResponse(ERROR_CODE.ID_DUPLICATION);
+        throw makeUniqueFieldsError(response, userData);
       }
       newUser = response.get({ plain: true });
       await createDefaultCategories(newUser.no, transaction);
     });
   } catch (error) {
-    if (isSubEmailUniqueConstraintError(error)) {
-      throw new ErrorResponse(ERROR_CODE.SUB_EMAIL_DUPLICATION);
-    }
-    throw error;
+    checkSubEmailUniqueConstraintError(error);
   }
 
   return newUser;

--- a/server/test/user/service.spec.js
+++ b/server/test/user/service.spec.js
@@ -55,7 +55,7 @@ describe('user service는...', () => {
 
     it('# 중복된 아이디인 경우 ErrorResponse instance를 반환한다. ', async () => {
       try {
-        newUser = await service.register(user);
+        newUser = await service.register({ ...user, sub_email: 'abcd@zzzz.zzz' });
       } catch (error) {
         error.should.be.instanceOf(ErrorResponse);
       }
@@ -63,7 +63,7 @@ describe('user service는...', () => {
 
     it('# 중복된 아이디인 경우 ERROR_CODE는 ID_DUPLICATION 이다', async () => {
       try {
-        newUser = await service.register(user);
+        newUser = await service.register({ ...user, sub_email: 'abcd@zzzz.zzz' });
       } catch (error) {
         const { errorCode } = error;
         errorCode.should.be.eql(ERROR_CODE.ID_DUPLICATION);
@@ -71,6 +71,58 @@ describe('user service는...', () => {
     });
 
     it('# 중복된 아이디인 경우 ErrorFields의 length는 0이다.', async () => {
+      try {
+        newUser = await service.register({ ...user, sub_email: 'abcd@zzzz.zzz' });
+      } catch (error) {
+        const { fieldErrors } = error;
+        fieldErrors.should.have.length(0);
+      }
+    });
+
+    it('# 중복된 서브 이메일인 경우 ErrorResponse instance를 반환한다. ', async () => {
+      try {
+        newUser = await service.register({ ...user, id: 'nanana' });
+      } catch (error) {
+        error.should.be.instanceOf(ErrorResponse);
+      }
+    });
+
+    it('# 중복된 서브 이메일인 경우 ERROR_CODE는 ID_DUPLICATION 이다', async () => {
+      try {
+        newUser = await service.register({ ...user, id: 'nanana' });
+      } catch (error) {
+        const { errorCode } = error;
+        errorCode.should.be.eql(ERROR_CODE.SUB_EMAIL_DUPLICATION);
+      }
+    });
+
+    it('# 중복된 서브 이메일인 경우 ErrorFields의 length는 0이다.', async () => {
+      try {
+        newUser = await service.register({ ...user, id: 'nanana' });
+      } catch (error) {
+        const { fieldErrors } = error;
+        fieldErrors.should.have.length(0);
+      }
+    });
+
+    it('# 아이디와 서브 이메일 모두 중복될 경우 ErrorResponse instance를 반환한다. ', async () => {
+      try {
+        newUser = await service.register({ ...user, id: 'nanana' });
+      } catch (error) {
+        error.should.be.instanceOf(ErrorResponse);
+      }
+    });
+
+    it('# 아이디와 서브 이메일 모두 중복될 경우  ERROR_CODE는 ID_AND_SUB_EMAIL_DUPLICATION 이다', async () => {
+      try {
+        newUser = await service.register(user);
+      } catch (error) {
+        const { errorCode } = error;
+        errorCode.should.be.eql(ERROR_CODE.ID_AND_SUB_EMAIL_DUPLICATION);
+      }
+    });
+
+    it('# 아이디와 서브 이메일 모두 중복될 경우 ErrorFields의 length는 0이다.', async () => {
       try {
         newUser = await service.register(user);
       } catch (error) {


### PR DESCRIPTION
### 무엇을 (What)
1. 이메일 중복 가입 처리를 위한 에러 처리 코드 추가. 가입시 아이디만 중복되거나, 이메일만 중복되거나 아이디와 이메일이 중복되는 경우가 발생할 수 있어서 경우에 따라 에러 메시지 반환

### 왜 그 방법을 선택했는가? (Why)
1. 기존 코드(테스트, 클라이언트 에러 처리)를 최대한 바꾸지 않고 작성을 하기 위해 해당 방법을 선택함.

### 리뷰어 참고사항

