### PR TITLE
회원가입,로그인 버그 수정 #311 #318 #321 #322

### DIFF
--- a/web/components/Forms/FindIdForm/index.js
+++ b/web/components/Forms/FindIdForm/index.js
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Router from 'next/router';
-import axios from 'axios';
 import { TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 import SmallHeader from '../../SmallHeader';
 import validator from '../../../utils/validator';
-import { errorParser } from '../../../utils/error-parser';
 import S from './styled';
+import { AppDispatchContext } from '../../../contexts';
+import { SUCCESS_EMAIL_SEND_TO_FIND_ID } from '../../../utils/success-message';
+import { setMessage } from '../../../contexts/reducer';
+import request from '../../../utils/request';
 
 const useStyles = makeStyles(theme => ({
   textField: {
@@ -23,14 +25,16 @@ const FindIdForm = () => {
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
 
+  const { dispatch } = useContext(AppDispatchContext);
+
   const findIdByEmail = async () => {
-    try {
-      const body = { email };
-      await axios.post('/users/search?type=id', body);
+    const body = { email };
+    const { isError, data } = await request.post('/users/search?type=id', body);
+    if (isError) {
+      setError(data.message);
+    } else {
+      dispatch(setMessage(SUCCESS_EMAIL_SEND_TO_FIND_ID));
       Router.push('/login');
-    } catch (err) {
-      const message = errorParser(err);
-      setError(message);
     }
   };
 

--- a/web/components/Forms/FindPwForm/index.js
+++ b/web/components/Forms/FindPwForm/index.js
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Router from 'next/router';
-import axios from 'axios';
 import { TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 import SmallHeader from '../../SmallHeader';
 import validator from '../../../utils/validator';
-import { errorParser } from '../../../utils/error-parser';
 import S from './styled';
+import { AppDispatchContext } from '../../../contexts';
+import { SUCCESS_EMAIL_SEND_TO_FIND_PASSWORD } from '../../../utils/success-message';
+import { setMessage } from '../../../contexts/reducer';
+import request from '../../../utils/request';
 
 const useStyles = makeStyles(theme => ({
   textField: {
@@ -34,6 +36,8 @@ const FindPwForm = () => {
   const [values, setValues] = useState(initialInputState);
   const [errors, setErrorMsg] = useState(initialErrorState);
 
+  const { dispatch } = useContext(AppDispatchContext);
+
   const handleInputChange = prop => ({ target }) => {
     setValues({ ...values, [prop]: target.value });
   };
@@ -43,13 +47,13 @@ const FindPwForm = () => {
   };
 
   const findPasswordByIdAndEmail = async () => {
-    try {
-      const body = { id: values.id, email: values.email };
-      await axios.post('/users/search?type=pw', body);
+    const body = { id: values.id, email: values.email };
+    const { isError, data } = await request.post('/users/search?type=pw', body);
+    if (isError) {
+      setSearchErrMsg(data.message);
+    } else {
+      dispatch(setMessage(SUCCESS_EMAIL_SEND_TO_FIND_PASSWORD));
       Router.push('/login');
-    } catch (err) {
-      const message = errorParser(err);
-      setSearchErrMsg(message);
     }
   };
 

--- a/web/components/Forms/PwChangeForm/index.js
+++ b/web/components/Forms/PwChangeForm/index.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import axios from 'axios';
 import {
   TextField,
   Button,
@@ -13,9 +12,9 @@ import {
 import { makeStyles } from '@material-ui/core/styles';
 
 import validator from '../../../utils/validator';
-import { errorParser } from '../../../utils/error-parser';
 import { ERROR_DIFFERENT_PASSWORD } from '../../../utils/error-message';
 import S from './styled';
+import request from '../../../utils/request';
 
 const useStyles = makeStyles(theme => ({
   textField: {
@@ -67,14 +66,13 @@ const PasswordModal = () => {
   };
 
   const updatePassword = async () => {
-    try {
-      const { password } = values;
-      const body = { password };
-      await axios.patch('/users/password', body);
+    const { password } = values;
+    const body = { password };
+    const { isError, data } = await request.patch('/users/password', body);
+    if (isError) {
+      handleChangeErrMsg(data.message);
+    } else {
       handleOpen();
-    } catch (err) {
-      const message = errorParser(err);
-      handleChangeErrMsg(message);
     }
   };
 

--- a/web/components/Forms/RegisterForm/index.js
+++ b/web/components/Forms/RegisterForm/index.js
@@ -61,6 +61,20 @@ const RegisterForm = () => {
     }
   };
 
+  const handlePasswordInputBlur = () => {
+    const errMsgs = { password: '', checkPassword: '' };
+
+    errMsgs.password = validator.validateAndGetMsg('password', values.password, true);
+    if (
+      (values.checkPassword !== '' || errors.checkPassword !== '') &&
+      values.password !== values.checkPassword
+    ) {
+      errMsgs.checkPassword = ERROR_DIFFERENT_PASSWORD;
+    }
+
+    setErrorMsg({ ...errors, ...errMsgs });
+  };
+
   const handlePasswordShowClick = () => {
     setValues({ ...values, showPassword: !values.showPassword });
   };
@@ -150,7 +164,7 @@ const RegisterForm = () => {
           id="password"
           label="비밀번호"
           onChange={handleInputChange('password')}
-          onBlur={handleInputBlur('password')}
+          onBlur={handlePasswordInputBlur}
           className={classes.textField}
           error={errors.password !== ''}
           type={values.showPassword ? 'text' : 'password'}

--- a/web/components/Forms/RegisterForm/index.js
+++ b/web/components/Forms/RegisterForm/index.js
@@ -5,7 +5,7 @@ import { Visibility, VisibilityOff } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
 
 import validator from '../../../utils/validator';
-import { errorParser } from '../../../utils/error-parser';
+import { errorParser, registerErrorMessageParser } from '../../../utils/error-parser';
 import { ERROR_DIFFERENT_PASSWORD } from '../../../utils/error-message';
 import { SUCCESS_REGISTER } from '../../../utils/success-message';
 import S from './styled';
@@ -88,8 +88,13 @@ const RegisterForm = () => {
     const body = { id, password, sub_email: email, name: name.trim() };
     const { isError, data } = await request.post('/users', body);
     if (isError) {
-      const { message } = errorParser(data);
-      handleRegisterErrMsg(message);
+      let { message } = errorParser(data);
+      message = registerErrorMessageParser(message);
+      if (message.id || message.email) {
+        setErrorMsg({ ...errors, ...message });
+      } else {
+        handleRegisterErrMsg(message);
+      }
       return;
     }
     dispatch(setMessage(SUCCESS_REGISTER));

--- a/web/utils/error-message.js
+++ b/web/utils/error-message.js
@@ -4,6 +4,9 @@ const ERROR_PASSWORD_EMPTY = '비밀번호가 입력되지 않았습니다';
 const ERROR_PASSWORD_VALIDATION = '잘못된 비밀번호입니다.';
 const ERROR_DIFFERENT_PASSWORD = '같은 비밀번호를 입력해주세요.';
 const ERROR_CANNOT_RESERVATION = '이미 지난 날짜입니다.';
+const ERROR_ID_DUPLICATION = '이미 사용중인 아이디 입니다.';
+const ERROR_SUB_EMAIL_DUPLICATION = '이미 가입에 사용한 이메일 입니다.';
+const ERROR_ID_AND_SUB_EMAIL_DUPLICATION = '이미 아이디와 이메일을 이미 사용하였습니다.';
 
 export {
   ERROR_ID_EMPTY,
@@ -12,4 +15,7 @@ export {
   ERROR_PASSWORD_VALIDATION,
   ERROR_DIFFERENT_PASSWORD,
   ERROR_CANNOT_RESERVATION,
+  ERROR_ID_DUPLICATION,
+  ERROR_SUB_EMAIL_DUPLICATION,
+  ERROR_ID_AND_SUB_EMAIL_DUPLICATION,
 };

--- a/web/utils/error-parser.js
+++ b/web/utils/error-parser.js
@@ -1,6 +1,29 @@
+import {
+  ERROR_ID_AND_SUB_EMAIL_DUPLICATION,
+  ERROR_ID_DUPLICATION,
+  ERROR_SUB_EMAIL_DUPLICATION,
+} from './error-message';
+
 const isContainedErrorCode = error => {
   const { response } = error;
   return response && response.data && response.data.errorCode;
+};
+
+const registerErrorMessageParser = errorMsg => {
+  const errorMsgs = {};
+
+  if (errorMsg === ERROR_ID_AND_SUB_EMAIL_DUPLICATION) {
+    errorMsgs.id = ERROR_ID_DUPLICATION;
+    errorMsgs.email = ERROR_SUB_EMAIL_DUPLICATION;
+  } else if (errorMsg === ERROR_ID_DUPLICATION) {
+    errorMsgs.id = ERROR_ID_DUPLICATION;
+  } else if (errorMsg === ERROR_SUB_EMAIL_DUPLICATION) {
+    errorMsgs.email = ERROR_SUB_EMAIL_DUPLICATION;
+  } else {
+    return errorMsg;
+  }
+
+  return errorMsgs;
 };
 
 const errorParser = error => {
@@ -23,4 +46,4 @@ const errorParser = error => {
   return { status: 400, message: errorMessage };
 };
 
-export { errorParser };
+export { isContainedErrorCode, errorParser, registerErrorMessageParser };

--- a/web/utils/success-message.js
+++ b/web/utils/success-message.js
@@ -1,3 +1,5 @@
 const SUCCESS_REGISTER = '회원가입이 완료되었습니다. 환영합니다! ';
+const SUCCESS_EMAIL_SEND_TO_FIND_ID = '이메일로 아이디를 성공적으로 보냈습니다.';
+const SUCCESS_EMAIL_SEND_TO_FIND_PASSWORD = '이메일로 임시 비밀번호를 성공적으로 보냈습니다.';
 
-export { SUCCESS_REGISTER };
+export { SUCCESS_REGISTER, SUCCESS_EMAIL_SEND_TO_FIND_ID, SUCCESS_EMAIL_SEND_TO_FIND_PASSWORD };


### PR DESCRIPTION
### 무엇을 (What)
1. 프론트엔드 버그 수정
- 아이디, 비밀번호 찾기 에러 #311
  - request 모듈을 사용
- 회원가입시 중복 이메일 에러 메시지 #318
  - 서버에서 아이디, 이메일 중복일 경우 에러 메시지를 적절히 반환
- 회원가입시 중복 아이디 에러 메시지 표시 위치 #321
  - 메시지 내용에 따라 위치를 정하도록 함
- 비밀번호 포커스 아웃 문제 #322
  - password 처리 핸들러를 따로 만듬
### 왜 그 방법을 선택했는가? (Why)
1. 회원가입시 중복 이메일, 아이디 에러 메시지 처리 같은 경우 request 모듈에서 status, message를 꺼내어 반환하기 때문에 message 내용에 따라 에러 메시지를 표시할 위치를 정하도록 함

### 리뷰어 참고사항
라우팅 문제, 로그아웃 문제 해결 필요
