### PR TITLE
[BE] id로 가입한 회원과 sub_email로 가입한 회원이 서로 다를 경우 처리

### DIFF
--- a/server/src/database/models/user.js
+++ b/server/src/database/models/user.js
@@ -3,6 +3,8 @@
 /* eslint-disable no-await-in-loop */
 import { createSalt, encrypt, aesEncrypt, aesDecrypt } from '../../libraries/crypto';
 
+import { Op } from 'sequelize';
+
 const { DEFAULT_DOMAIN_NAME } = process.env;
 
 const convertToUserModel = async instance => {
@@ -182,6 +184,27 @@ const model = (sequelize, DataTypes) => {
       },
     });
   };
+
+  User.findAllUserByIdAndSubEmail = ({ id, sub_email }) => {
+    return User.findAll({
+      where: {
+        [Op.or]: [
+          {
+            id: {
+              [Op.eq]: id,
+            },
+          },
+          {
+            sub_email: {
+              [Op.eq]: sub_email,
+            },
+          },
+        ],
+      },
+      raw: true,
+    });
+  };
+
   return User;
 };
 

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -52,7 +52,8 @@ const register = async ({ id, password, name, sub_email }) => {
       if (users.length !== 0) {
         throwUniqueFieldsError(users, id, sub_email);
       }
-      newUser = await DB.User.create(userData, { transaction, raw: true });
+      newUser = await DB.User.create(userData, { transaction });
+      newUser = newUser.get({ plain: true });
       await createDefaultCategories(newUser.no, transaction);
     });
   } catch (error) {

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -2,7 +2,6 @@ import generator from 'generate-password';
 
 import DB from '../../database';
 import ErrorResponse from '../../libraries/exception/error-response';
-import ErrorField from '../../libraries/exception/error-field';
 import ERROR_CODE from '../../libraries/exception/error-code';
 import mailUtil from '../../libraries/mail-util';
 import { encrypt, aesEncrypt } from '../../libraries/crypto';


### PR DESCRIPTION
### 무엇을 (What)
1. 가입시 넘겨준 id와 sub_email에 정보를 가진 회원이 각각 다를 경우 (id로 sub_email' 정보로 가입한 회원, id', sub_email 정보로 가입한 회원)를 따로 처리를 할 수 있도록 함

### 왜 그 방법을 선택했는가? (Why)
1. id, sub_email 정보로 가입한 회원이 2명이 될 수 있음. 반면 findOrCreateById 함수는 한 명의 회원만 반환하여 제대로 된 에러처리가 안되는 경우가 발생할 수 있음

### 리뷰어 참고사항

