### PR TITLE
fix(be/attachment): 첨부파일 확장자 검사 블랙리스트로 변경 #317

### DIFF
--- a/server/src/libraries/validation/attachment.js
+++ b/server/src/libraries/validation/attachment.js
@@ -2,30 +2,78 @@ import ERROR_CODE from '../exception/error-code';
 import ErrorField from '../exception/error-field';
 import ErrorResponse from '../exception/error-response';
 
-const MB = 1024 * 1024;
-const FILE_MAX_SIZE = 9 * MB;
+const MB = 1000 * 1000;
+const FILE_MAX_SIZE = 10 * MB;
 
-const AVAILABLE_MIME_TYPE = {
-  'text/plain': true,
-  'text/csv': true,
-  'text/html': true,
-  'application/vnd.ms-powerpoint': true,
-  'application/haansoftxlsx': true,
-  'application/pdf': true,
-  'application/x-font-ttf': true,
-  'application/zip': true,
-  'application/json': true,
-  'application/haansoftpptx': true,
-  'application/vnd.ms-excel': true,
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': true,
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation': true,
-  'application/msword': true,
-  'image/jpeg': true,
-  'image/png': true,
-  'image/jpg': true,
-  'image/bmp': true,
-  'image/gif': true,
-  '': true,
+const UNAVAILABLE_EXTENSION = {
+  bat: true,
+  cmd: true,
+  com: true,
+  cpl: true,
+  exe: true,
+  js: true,
+  scr: true,
+  vds: true,
+  wsf: true,
+  jse: true,
+  adp: true,
+  chm: true,
+  hta: true,
+  lnk: true,
+  mde: true,
+  msc: true,
+  msi: true,
+  msp: true,
+  mst: true,
+  pif: true,
+  sct: true,
+  shb: true,
+  vb: true,
+  vbe: true,
+  wsc: true,
+  wsh: true,
+  ade: true,
+  jar: true,
+  bas: true,
+  cer: true,
+  crt: true,
+  der: true,
+  gadget: true,
+  hlp: true,
+  inf: true,
+  mad: true,
+  maf: true,
+  mag: true,
+  mam: true,
+  maq: true,
+  mar: true,
+  mas: true,
+  mat: true,
+  mau: true,
+  mav: true,
+  maw: true,
+  mda: true,
+  mdb: true,
+  mdt: true,
+  mdw: true,
+  mdz: true,
+  reg: true,
+  scf: true,
+  shs: true,
+  ps1: true,
+  ps1xml: true,
+  ps2: true,
+  ps2xml: true,
+  psc1: true,
+  psc2: true,
+  url: true,
+  grp: true,
+  xbap: true,
+  ocx: true,
+  nsh: true,
+  sys: true,
+  vxd: true,
+  jnlp: true,
 };
 
 const add = (a, b) => a + b;
@@ -35,11 +83,27 @@ const getTotalSize = sizes => {
   return sum;
 };
 
-const checkMimeType = mimetypes => mimetypes.every(mimetype => AVAILABLE_MIME_TYPE[mimetype]);
+const checkExtension = fileNames => {
+  const errors = [];
+  for (const fileName of fileNames) {
+    const splitedFileName = fileName.split('.');
+    let extension = splitedFileName[splitedFileName.length - 1];
+    extension = extension.toLowerCase();
+
+    if (UNAVAILABLE_EXTENSION[extension]) {
+      errors.push(fileName);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw errors.join('  ');
+  }
+  return true;
+};
 
 const checkAttachment = files => {
   const sizes = files.map(file => file.size);
-  const mimetypes = files.map(file => file.mimetype);
+  const fileNames = files.map(file => file.originalname);
   const errorFields = [];
 
   const totalSize = getTotalSize(sizes);
@@ -48,11 +112,13 @@ const checkAttachment = files => {
     errorFields.push(errorField);
   }
 
-  if (!checkMimeType(mimetypes)) {
+  try {
+    checkExtension(fileNames);
+  } catch (error) {
     const errorField = new ErrorField(
-      'mimetype',
-      mimetypes,
-      '허용되지 않는 mimetype이 포함되어 있습니다.',
+      'file extension',
+      error,
+      '허용되지 않는 확장자가 포함되어 있습니다.',
     );
     errorFields.push(errorField);
   }
@@ -64,4 +130,4 @@ const checkAttachment = files => {
   return true;
 };
 
-export { checkAttachment, checkMimeType, getTotalSize };
+export { checkAttachment, checkExtension, getTotalSize };

--- a/server/src/libraries/validation/attachment.js
+++ b/server/src/libraries/validation/attachment.js
@@ -96,7 +96,7 @@ const checkExtension = fileNames => {
   }
 
   if (errors.length > 0) {
-    throw errors.join('  ');
+    throw errors.join(' ');
   }
   return true;
 };

--- a/server/test/date-parser.spec.js
+++ b/server/test/date-parser.spec.js
@@ -1,11 +1,13 @@
 import should from 'should';
 import { strToDate } from '../src/libraries/date-parser';
 
-describe('strToDate 함수는..', () => {
-  it('# "YYYY:MM:DD HH:mm" 형태의 문자열을 넘겨줄 경우 Date 형식으로 넘겨준다.', () => {
-    const str = '2000:12:01 03:00';
+describe('date-parser는.....', () => {
+  describe('strToDate 함수는..', () => {
+    it('# "YYYY:MM:DD HH:mm" 형태의 문자열을 넘겨줄 경우 Date 형식으로 넘겨준다.', () => {
+      const str = '2000:12:01 03:00';
 
-    const date = strToDate(str);
-    date.should.eql(new Date(2000, 11, 1, 3, 0));
+      const date = strToDate(str);
+      date.should.eql(new Date(2000, 11, 1, 3, 0));
+    });
   });
 });

--- a/server/test/libraries/mail/attachment.spec.js
+++ b/server/test/libraries/mail/attachment.spec.js
@@ -2,7 +2,7 @@
 import should from 'should';
 import {
   checkAttachment,
-  checkMimeType,
+  checkExtension,
   getTotalSize,
 } from '../../../src/libraries/validation/attachment';
 
@@ -17,54 +17,64 @@ describe('attachment validation...', () => {
     });
   });
 
-  describe('checkMimeTyep은...', () => {
-    it('사용가능한 mimetype이면 true를 반환한다.', () => {
-      const mimetypes = ['application/vnd.ms-powerpoint', 'image/jpeg', 'application/json'];
-      checkMimeType(mimetypes).should.be.true();
+  describe('checkExtension은.....', () => {
+    it('이용가능한 확장자면 true를 반환한다.', () => {
+      const filenames = ['asd.png', 'dqw.jpg', 'ddqw.md', 'dqw.html'];
+      checkExtension(filenames).should.be.true();
     });
 
-    it('사용 불가능한 mimetype이면 false를 반환한다..', () => {
-      let mimetypes = ['application/vnd.ms-powerpoint2'];
-      checkMimeType(mimetypes).should.be.false();
+    it('이용 불가능한 확장자면 throw을 던진다..', () => {
+      const filenames = ['asd.png', 'dqw.jpg', 'ddqw.md', 'dqw.js'];
+      try {
+        checkExtension(filenames);
+      } catch (error) {
+        error.should.be.equals('dqw.js');
+      }
+    });
 
-      mimetypes = ['md'];
-      checkMimeType(mimetypes).should.be.false();
+    it('이용 불가능한 확장자면 throw을 던진다2..', () => {
+      const filenames = ['asd.ps1', 'dqw.scf', 'ddqw.md', 'dqw.js'];
+      try {
+        checkExtension(filenames);
+      } catch (error) {
+        error.should.be.equals('asd.ps1 dqw.scf dqw.js');
+      }
+    });
 
-      mimetypes = ['application/js'];
-      checkMimeType(mimetypes).should.be.false();
-
-      mimetypes = ['text/js'];
-      checkMimeType(mimetypes).should.be.false();
-
-      mimetypes = ['text/js', 'text/py'];
-      checkMimeType(mimetypes).should.be.false();
+    it('이용 불가능한 확장자면 throw을 던진다3..', () => {
+      const filenames = ['asd.png', 'dqw.bat', 'ddqw.md', 'dqw.js'];
+      try {
+        checkExtension(filenames);
+      } catch (error) {
+        error.should.be.equals('dqw.bat dqw.js');
+      }
     });
   });
 
   describe('checkAttachment은...', () => {
-    const MB = 1024 * 1024;
+    const MB = 1000 * 1000;
 
     it('totalSize가 크면 에러를 반환한다..', () => {
       const files = [
         {
           size: 5 * MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: 5 * MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: 5 * MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: 5 * MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: 5 * MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
       ];
       try {
@@ -78,27 +88,27 @@ describe('attachment validation...', () => {
       }
     });
 
-    it('허용되지 않는 mimetype이 포함된경우 에러를 반환한다', () => {
+    it('허용되지 않는 extension이 포함된경우 에러를 반환한다', () => {
       const files = [
         {
           size: MB,
-          mimetype: 'text/value',
+          originalname: 'tes.bat',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'text/plain',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'text/plain',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'text/plain',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'text/plain',
         },
       ];
       try {
@@ -107,9 +117,8 @@ describe('attachment validation...', () => {
         const { errorCode, fieldErrors } = err;
         errorCode.status.should.be.equals(400);
         errorCode.message.should.be.equals('INVALID INPUT VALUE');
-        fieldErrors[0].field.should.be.equals('mimetype');
-        fieldErrors[0].reason.should.be.equals('허용되지 않는 mimetype이 포함되어 있습니다.');
-        fieldErrors[0].value.should.an.instanceof(Array);
+        fieldErrors[0].field.should.be.equals('file extension');
+        fieldErrors[0].reason.should.be.equals('허용되지 않는 확장자가 포함되어 있습니다.');
       }
     });
 
@@ -117,23 +126,23 @@ describe('attachment validation...', () => {
       const files = [
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
         {
           size: MB,
-          mimetype: 'text/plain',
+          originalname: 'tes.txt',
         },
       ];
       checkAttachment(files).should.be.true();


### PR DESCRIPTION
### 무엇을 (What)
1. 메일전송시 첨부파일를 미디어타입 검사에서 확장자 검사로 변경

### 왜 그 방법을 선택했는가? (Why)
1. 네이버에서 제공하는 블랙리스트를 발견함

### 리뷰어 참고사항

