### PR TITLE
[BE] 회원 탈퇴 API 구현 #334

### DIFF
--- a/server/src/database/models/address.js
+++ b/server/src/database/models/address.js
@@ -28,7 +28,7 @@ const model = (sequelize, DataTypes) => {
   );
 
   Address.associate = ({ User }) => {
-    Address.belongsTo(User, { foreignKey: 'user_no', targetKey: 'no' });
+    Address.belongsTo(User, { foreignKey: 'user_no', targetKey: 'no', onDelete: 'cascade' });
   };
 
   Address.findAllByUserNo = userNo => {

--- a/server/src/database/models/category.js
+++ b/server/src/database/models/category.js
@@ -60,9 +60,12 @@ const model = (sequelize, DataTypes) => {
   };
 
   Category.associate = ({ User, Mail, ClassificationPattern }) => {
-    Category.belongsTo(User, { foreignKey: 'user_no', targetKey: 'no' });
+    Category.belongsTo(User, { foreignKey: 'user_no', targetKey: 'no', onDelete: 'cascade' });
     Category.hasMany(Mail, { foreignKey: 'category_no', sourceKey: 'no' });
-    Category.hasMany(ClassificationPattern, { foreignKey: 'category_no', sourceKey: 'no' });
+    Category.hasMany(ClassificationPattern, {
+      foreignKey: 'category_no',
+      sourceKey: 'no',
+    });
   };
 
   return Category;

--- a/server/src/database/models/mail.js
+++ b/server/src/database/models/mail.js
@@ -60,9 +60,9 @@ const model = (sequelize, DataTypes) => {
   );
 
   Mail.associate = ({ User, MailTemplate, Category }) => {
-    Mail.belongsTo(User, { foreignKey: 'owner', targetKey: 'no' });
+    Mail.belongsTo(User, { foreignKey: 'owner', targetKey: 'no', onDelete: 'cascade' });
     Mail.belongsTo(MailTemplate, { foreignKey: 'mail_template_id', targetKey: 'no' });
-    Mail.belongsTo(Category, { foreignKey: 'category_no', targetKey: 'no' });
+    Mail.belongsTo(Category, { foreignKey: 'category_no', targetKey: 'no', onDelete: 'cascade' });
   };
 
   Mail.findAndCountAllFilteredMail = ({

--- a/server/src/database/models/user.js
+++ b/server/src/database/models/user.js
@@ -205,6 +205,13 @@ const model = (sequelize, DataTypes) => {
     });
   };
 
+  User.destroyByNo = no => {
+    return User.destroy({
+      where: { no },
+      cascade: true,
+    });
+  };
+
   return User;
 };
 

--- a/server/src/v1/users/controller.js
+++ b/server/src/v1/users/controller.js
@@ -52,4 +52,14 @@ const updatePassword = async (req, res, next) => {
   return res.status(status.NO_CONTENT).end();
 };
 
-export default { registerUser, updatePassword, search };
+const removeUser = async (req, res, next) => {
+  try {
+    await service.destroy(req.user);
+  } catch (err) {
+    return next(err);
+  }
+
+  return res.status(status.NO_CONTENT).end();
+};
+
+export default { registerUser, updatePassword, search, removeUser };

--- a/server/src/v1/users/index.js
+++ b/server/src/v1/users/index.js
@@ -9,6 +9,7 @@ router.get('/', (req, res) => {
 });
 
 router.post('/', ctrl.registerUser);
+router.delete('/', isAuth, ctrl.removeUser);
 router.post('/search', ctrl.search);
 router.patch('/password', isAuth, ctrl.updatePassword);
 

--- a/server/src/v1/users/service.js
+++ b/server/src/v1/users/service.js
@@ -5,6 +5,7 @@ import ErrorResponse from '../../libraries/exception/error-response';
 import ERROR_CODE from '../../libraries/exception/error-code';
 import mailUtil from '../../libraries/mail-util';
 import { encrypt, aesEncrypt } from '../../libraries/crypto';
+import { deleteAllMailBox } from '../../libraries/save-to-infra';
 
 const DEFAULT_CATEGORIES = ['받은메일함', '보낸메일함', '내게쓴메일함', '휴지통'];
 const TEMP_PASSWORD_LENGTH = 15;
@@ -104,8 +105,19 @@ const sendUserPasswordToEmail = async (id, email) => {
   return true;
 };
 
+const destroy = async user => {
+  /*
+    TODO - Delete IMAP Mail Box
+    subscriptions 파일에 적힌 메일함은 삭제됨. "받은메일함"은 삭제가 되지 않음
+    const categories = await DB.Category.findAllByUserNo(user.no);
+    await deleteAllMailBox({ user, categories });
+  */
+  await DB.User.destroyByNo(user.no);
+};
+
 export default {
   register,
+  destroy,
   updatePassword,
   createDefaultCategories,
   sendUserIdToEmail,

--- a/server/test/user/api.spec.js
+++ b/server/test/user/api.spec.js
@@ -405,3 +405,44 @@ describe('PATCH /users/password는...', () => {
     });
   });
 });
+
+describe('DELETE /users/는...', () => {
+  before(async () => {
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
+    await DB.sequelize.sync({ force: true });
+    await DB.sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
+    await mock();
+  });
+
+  describe('로그인 하지 않은 상태로..', () => {
+    it('탈퇴를 하고자 한다면 하면 401에러를 반환한다', done => {
+      request(app)
+        .delete('/users')
+        .expect(401, done);
+    });
+  });
+
+  describe('로그인 한 상태로..', () => {
+    const userCredentials = {
+      id: 'rooot',
+      password: '12345678',
+    };
+    const authenticatedUser = request.agent(app);
+
+    before(done => {
+      authenticatedUser
+        .post('/auth/login')
+        .send(userCredentials)
+        .expect(200, done);
+    });
+
+    it('탈퇴를 성공하면 204를 반환하며 다시 로그인 할 수 없다.', async () => {
+      await authenticatedUser.delete('/users').expect(204);
+
+      await authenticatedUser
+        .post('/auth/login')
+        .send(userCredentials)
+        .expect(401);
+    });
+  });
+});


### PR DESCRIPTION
### 무엇을 (What)
1. 회원 탈퇴 API 구현
2. 회원과 관련된 테이블 onDelete='casecade' 적용
3. 회원의 imap 메일함을 삭제하는 함수 작성을 했지만 사용하지 않음
 
### 왜 그 방법을 선택했는가? (Why)
1. 회원 삭제시 관련 record(카테고리, 메일, 주소록)를 삭제하도록 함
2. 회원 메일함 삭제시 "받은메일함" 같은 경우 imap에서 삭제가 되지 않아 일단 imap 메일함 삭제는 추후에 작성할 예정

### 리뷰어 참고사항

