### PR TITLE
[FE] 체크박스를 통해 메일삭제 #344 / 메일 영구 삭제 #238

### DIFF
--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -2,14 +2,9 @@
 import React, { useContext } from 'react';
 import moment from 'moment';
 import { FormControlLabel, Checkbox } from '@material-ui/core';
-import StarBorderIcon from '@material-ui/icons/StarBorder';
-import StarIcon from '@material-ui/icons/Star';
-import MailIcon from '@material-ui/icons/Mail';
-import DraftsIcon from '@material-ui/icons/Drafts';
-import DeleteIcon from '@material-ui/icons/Delete';
-import LoopIcon from '@material-ui/icons/Loop';
+import { StarBorder, Star, Mail, Drafts, Delete, DeleteForever } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
-import { red, yellow, green } from '@material-ui/core/colors';
+import { red, yellow } from '@material-ui/core/colors';
 import { handleMailChecked } from '../../../contexts/reducer';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
 import * as S from './styled';
@@ -32,11 +27,6 @@ const useStyles = makeStyles(() => ({
     color: yellow[800],
     '&:hover': {
       color: '#1976d2',
-    },
-  },
-  recycle: {
-    '&:hover': {
-      color: green[800],
     },
   },
 }));
@@ -86,19 +76,19 @@ const MailTemplate = ({ mail, selected, index, categories }) => {
       </div>
       <S.ImportantButton id={`star-${index}`}>
         {is_important ? (
-          <StarIcon className={classes.star} id={`star-${index}`} />
+          <Star className={classes.star} id={`star-${index}`} />
         ) : (
-          <StarBorderIcon className={classes.unstar} id={`star-${index}`} />
+          <StarBorder className={classes.unstar} id={`star-${index}`} />
         )}
       </S.ImportantButton>
-      <S.ReadSign>{is_read ? <DraftsIcon /> : <MailIcon />}</S.ReadSign>
+      <S.ReadSign>{is_read ? <Drafts /> : <Mail />}</S.ReadSign>
       {state.category === wastebasketNo ? (
-        <S.RecycleButton id={`recycle-${index}`}>
-          <LoopIcon className={classes.recycle} id={`recycle-${index}`} />
-        </S.RecycleButton>
+        <S.ForeverDeleteButton id={`foreverDelete-${index}`}>
+          <DeleteForever className={classes.delete} id={`foreverDelete-${index}`} />
+        </S.ForeverDeleteButton>
       ) : (
         <S.DeleteButton id={`delete-${index}`}>
-          <DeleteIcon className={classes.delete} id={`delete-${index}`} />
+          <Delete className={classes.delete} id={`delete-${index}`} />
         </S.DeleteButton>
       )}
       <S.From isRead={is_read}>{from}</S.From>

--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -2,7 +2,14 @@
 import React, { useContext } from 'react';
 import moment from 'moment';
 import { FormControlLabel, Checkbox } from '@material-ui/core';
-import { StarBorder, Star, Mail, Drafts, Delete, DeleteForever } from '@material-ui/icons';
+import {
+  StarBorder as StarBorderIcon,
+  Star as StarIcon,
+  Mail as MailIcon,
+  Drafts as DraftsIcon,
+  Delete as DeleteIcon,
+  DeleteForever as DeleteForeverIcon,
+} from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
 import { red, yellow } from '@material-ui/core/colors';
 import { handleMailChecked } from '../../../contexts/reducer';
@@ -76,19 +83,19 @@ const MailTemplate = ({ mail, selected, index, categories }) => {
       </div>
       <S.ImportantButton id={`star-${index}`}>
         {is_important ? (
-          <Star className={classes.star} id={`star-${index}`} />
+          <StarIcon className={classes.star} id={`star-${index}`} />
         ) : (
-          <StarBorder className={classes.unstar} id={`star-${index}`} />
+          <StarBorderIcon className={classes.unstar} id={`star-${index}`} />
         )}
       </S.ImportantButton>
-      <S.ReadSign>{is_read ? <Drafts /> : <Mail />}</S.ReadSign>
+      <S.ReadSign>{is_read ? <DraftsIcon /> : <MailIcon />}</S.ReadSign>
       {state.category === wastebasketNo ? (
         <S.ForeverDeleteButton id={`foreverDelete-${index}`}>
-          <DeleteForever className={classes.delete} id={`foreverDelete-${index}`} />
+          <DeleteForeverIcon className={classes.delete} id={`foreverDelete-${index}`} />
         </S.ForeverDeleteButton>
       ) : (
         <S.DeleteButton id={`delete-${index}`}>
-          <Delete className={classes.delete} id={`delete-${index}`} />
+          <DeleteIcon className={classes.delete} id={`delete-${index}`} />
         </S.DeleteButton>
       )}
       <S.From isRead={is_read}>{from}</S.From>

--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -90,9 +90,9 @@ const MailTemplate = ({ mail, selected, index, categories }) => {
       </S.ImportantButton>
       <S.ReadSign>{is_read ? <DraftsIcon /> : <MailIcon />}</S.ReadSign>
       {state.category === wastebasketNo ? (
-        <S.ForeverDeleteButton id={`foreverDelete-${index}`}>
-          <DeleteForeverIcon className={classes.delete} id={`foreverDelete-${index}`} />
-        </S.ForeverDeleteButton>
+        <S.DeleteForeverButton id={`deleteForever-${index}`}>
+          <DeleteForeverIcon className={classes.delete} id={`deleteForever-${index}`} />
+        </S.DeleteForeverButton>
       ) : (
         <S.DeleteButton id={`delete-${index}`}>
           <DeleteIcon className={classes.delete} id={`delete-${index}`} />

--- a/web/components/MailArea/MailTemplate/styled.js
+++ b/web/components/MailArea/MailTemplate/styled.js
@@ -29,7 +29,7 @@ const DeleteButton = styled.div`
   margin-right: 10px;
 `;
 
-const RecycleButton = styled.div`
+const ForeverDeleteButton = styled.div`
   cursor: pointer;
   flex: 0 0 40px;
   margin-right: 10px;
@@ -90,7 +90,7 @@ export {
   Container,
   ImportantButton,
   ReadSign,
-  RecycleButton,
+  ForeverDeleteButton,
   DeleteButton,
   From,
   Selectable,

--- a/web/components/MailArea/MailTemplate/styled.js
+++ b/web/components/MailArea/MailTemplate/styled.js
@@ -29,7 +29,7 @@ const DeleteButton = styled.div`
   margin-right: 10px;
 `;
 
-const ForeverDeleteButton = styled.div`
+const DeleteForeverButton = styled.div`
   cursor: pointer;
   flex: 0 0 40px;
   margin-right: 10px;
@@ -90,7 +90,7 @@ export {
   Container,
   ImportantButton,
   ReadSign,
-  ForeverDeleteButton,
+  DeleteForeverButton,
   DeleteButton,
   From,
   Selectable,

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -13,9 +13,27 @@ import {
 import { ArrowDownward, ArrowUpward, Email, Send, Delete, DeleteForever } from '@material-ui/icons';
 import S from './styled';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
-import { handleSortSelect, handleCheckAllMails } from '../../../contexts/reducer';
+import {
+  handleSortSelect,
+  handleCheckAllMails,
+  handleSnackbarState,
+  handleMailsChange,
+  initCheckerInTools,
+} from '../../../contexts/reducer';
+import getQueryByOptions from '../../../utils/query';
+import request from '../../../utils/request';
+import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
 
 const WASTEBASKET_NAME = '휴지통';
+
+const SNACKBAR_MSG = {
+  ERROR: {
+    DELETE: '메일 삭제를 실패하였습니다.',
+  },
+  SUCCESS: {
+    DELETE: count => `${count}개의 메일을 삭제하였습니다.`,
+  },
+};
 
 const useStyles = makeStyles(theme => ({
   formControl: {
@@ -43,6 +61,18 @@ const getArrowIcon = sortValue =>
     <ArrowDownward fontSize={'small'} />
   );
 
+const loadNewMails = async (query, dispatch) => {
+  const { isError, data } = await request.get(`/mail/?${query}`);
+  if (isError) {
+    throw SNACKBAR_MSG.ERROR.LOAD;
+  }
+  dispatch(handleMailsChange({ ...data }));
+};
+
+const updateMails = async (nos, props) => {
+  return request.patch(`/mail`, { nos, props });
+};
+
 const sortItems = SORT_TYPES.map(type => (
   <MenuItem key={type.value} value={type.value}>
     <S.SortItemView>
@@ -58,24 +88,45 @@ const buttons = [
     name: '답장',
     enable: true,
     icon: <Email />,
+    onClick: () => {},
   },
   {
     key: 'send',
     name: '전달',
     enable: true,
     icon: <Send />,
+    onClick: () => {},
   },
   {
     key: 'delete',
     name: '삭제',
     enable: true,
     icon: <Delete />,
+    onClick: async ({ mails, dispatch, query, wastebasketNo, openSnackbar }) => {
+      try {
+        const nos = mails.filter(({ selected }) => selected).map(({ no }) => no);
+        const deletedCount = nos.length;
+        if (deletedCount === 0) {
+          return;
+        }
+        const { isError } = await updateMails(nos, { category_no: wastebasketNo });
+        if (isError) {
+          throw SNACKBAR_MSG.ERROR.DELETE;
+        }
+        await loadNewMails(query, dispatch);
+        openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE(deletedCount));
+      } catch (errorMessage) {
+        openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
+      } finally {
+        dispatch(initCheckerInTools());
+      }
+    },
   },
   {
     key: 'forever_delete',
     name: '영구삭제',
-    icon: <DeleteForever />,
     enable: true,
+    icon: <DeleteForever />,
     onClick: () => {},
   },
 ];
@@ -88,7 +139,10 @@ const Tools = () => {
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
   const { allMailCheckInTools, mails, category, categoryNoByName } = state;
+  const query = getQueryByOptions(state);
   const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
+  const openSnackbar = (variant, message) =>
+    dispatch(handleSnackbarState(getSnackbarState(variant, message)));
   const handleFilterChange = ({ target: { value } }) => dispatch(handleSortSelect(value));
   const handleCheckAllChange = () => dispatch(handleCheckAllMails(allMailCheckInTools, mails));
 
@@ -108,6 +162,7 @@ const Tools = () => {
           color="primary"
           className={classes.button}
           startIcon={btn.icon}
+          onClick={btn.onClick.bind(null, { mails, dispatch, query, openSnackbar, wastebasketNo })}
           key={btn.key}>
           {btn.name}
         </Button>

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -125,7 +125,7 @@ const buttons = [
         await loadNewMails(query, dispatch);
         openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE(selectedMails.length));
       } catch (errorMessage) {
-        openSnackbar(SNACKBAR_VsARIANT.ERROR, errorMessage);
+        openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
         dispatch(handleCheckAllMails(true, selectedMails));
       } finally {
         dispatch(initCheckerInTools());

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -192,13 +192,15 @@ const Tools = () => {
           className={classes.button}
           startIcon={btn.icon}
           disabled={!selectedMails.length}
-          onClick={btn.onClick.bind(null, {
-            selectedMails,
-            dispatch,
-            query,
-            openSnackbar,
-            wastebasketNo,
-          })}
+          onClick={() =>
+            btn.onClick({
+              selectedMails,
+              dispatch,
+              query,
+              openSnackbar,
+              wastebasketNo,
+            })
+          }
           key={btn.key}>
           {btn.name}
         </Button>

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -32,11 +32,11 @@ const WASTEBASKET_NAME = '휴지통';
 const SNACKBAR_MSG = {
   ERROR: {
     DELETE: '메일 삭제를 실패하였습니다.',
-    FOREVER_DELETE: '메일 영구 삭제에 실패하였습니다.',
+    DELETE_FOREVER: '메일 영구 삭제에 실패하였습니다.',
   },
   SUCCESS: {
     DELETE: count => `${count}개의 메일을 삭제하였습니다.`,
-    FOREVER_DELETE: count => `${count}개의 메일을 영구 삭제하였습니다.`,
+    DELETE_FOREVER: count => `${count}개의 메일을 영구 삭제하였습니다.`,
   },
 };
 
@@ -133,7 +133,7 @@ const buttons = [
     },
   },
   {
-    key: 'forever_delete',
+    key: 'DELETE_FOREVER',
     name: '영구삭제',
     enable: true,
     icon: <DeleteForever />,
@@ -142,12 +142,12 @@ const buttons = [
         const nos = selectedMails.map(({ no }) => no);
         const { isError } = await removeMails(nos);
         if (isError) {
-          throw SNACKBAR_MSG.ERROR.FOREVER_DELETE;
+          throw SNACKBAR_MSG.ERROR.DELETE_FOREVER;
         }
         await loadNewMails(query, dispatch);
         openSnackbar(
           SNACKBAR_VARIANT.SUCCESS,
-          SNACKBAR_MSG.SUCCESS.FOREVER_DELETE(selectedMails.length),
+          SNACKBAR_MSG.SUCCESS.DELETE_FOREVER(selectedMails.length),
         );
       } catch (errorMessage) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
@@ -160,7 +160,7 @@ const buttons = [
 ];
 
 const deleteButton = buttons.find(button => button.key === 'delete');
-const foreverDeleteButton = buttons.find(button => button.key === 'forever_delete');
+const deleteForeverButton = buttons.find(button => button.key === 'DELETE_FOREVER');
 
 const Tools = () => {
   const classes = useStyles();
@@ -177,10 +177,10 @@ const Tools = () => {
 
   if (category === wastebasketNo) {
     deleteButton.enable = false;
-    foreverDeleteButton.enable = true;
+    deleteForeverButton.enable = true;
   } else {
     deleteButton.enable = true;
-    foreverDeleteButton.enable = false;
+    deleteForeverButton.enable = false;
   }
 
   const buttonSet = buttons.map(btn => {

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -19,6 +19,7 @@ import {
   handleSnackbarState,
   handleMailsChange,
   initCheckerInTools,
+  handlePageNumberClick,
 } from '../../../contexts/reducer';
 import getQueryByOptions from '../../../utils/query';
 import request from '../../../utils/request';
@@ -67,6 +68,10 @@ const loadNewMails = async (query, dispatch) => {
     throw SNACKBAR_MSG.ERROR.LOAD;
   }
   dispatch(handleMailsChange({ ...data }));
+  const { mails, paging } = data;
+  if (mails.length === 0) {
+    dispatch(handlePageNumberClick(paging.page));
+  }
 };
 
 const updateMails = async (nos, props) => {

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -10,10 +10,12 @@ import {
   ListItemText,
   Button,
 } from '@material-ui/core';
-import { ArrowDownward, ArrowUpward, Email, Send, Delete } from '@material-ui/icons';
+import { ArrowDownward, ArrowUpward, Email, Send, Delete, DeleteForever } from '@material-ui/icons';
 import S from './styled';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
 import { handleSortSelect, handleCheckAllMails } from '../../../contexts/reducer';
+
+const WASTEBASKET_NAME = '휴지통';
 
 const useStyles = makeStyles(theme => ({
   formControl: {
@@ -52,37 +54,65 @@ const sortItems = SORT_TYPES.map(type => (
 
 const buttons = [
   {
+    key: 'reply',
     name: '답장',
+    enable: true,
     icon: <Email />,
   },
   {
+    key: 'send',
     name: '전달',
+    enable: true,
     icon: <Send />,
   },
   {
+    key: 'delete',
     name: '삭제',
+    enable: true,
     icon: <Delete />,
   },
+  {
+    key: 'forever_delete',
+    name: '영구삭제',
+    icon: <DeleteForever />,
+    enable: true,
+    onClick: () => {},
+  },
 ];
+
+const deleteButton = buttons.find(button => button.key === 'delete');
+const foreverDeleteButton = buttons.find(button => button.key === 'forever_delete');
 
 const Tools = () => {
   const classes = useStyles();
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
-  const { allMailCheckInTools, mails } = state;
+  const { allMailCheckInTools, mails, category, categoryNoByName } = state;
+  const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
   const handleFilterChange = ({ target: { value } }) => dispatch(handleSortSelect(value));
   const handleCheckAllChange = () => dispatch(handleCheckAllMails(allMailCheckInTools, mails));
 
-  const buttonSet = buttons.map((btn, i) => (
-    <Button
-      variant="contained"
-      color="primary"
-      className={classes.button}
-      startIcon={btn.icon}
-      key={i}>
-      {btn.name}
-    </Button>
-  ));
+  if (category === wastebasketNo) {
+    deleteButton.enable = false;
+    foreverDeleteButton.enable = true;
+  } else {
+    deleteButton.enable = true;
+    foreverDeleteButton.enable = false;
+  }
+
+  const buttonSet = buttons.map(btn => {
+    if (btn.enable)
+      return (
+        <Button
+          variant="contained"
+          color="primary"
+          className={classes.button}
+          startIcon={btn.icon}
+          key={btn.key}>
+          {btn.name}
+        </Button>
+      );
+  });
 
   return (
     <>

--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -25,7 +25,7 @@ const ACTION = {
   STAR: 'star',
   DELETE: 'delete',
   READ: 'read',
-  RECYCLE: 'recycle',
+  FOREVER_DELETE: 'foreverDelete',
 };
 
 const SNACKBAR_MSG = {
@@ -34,13 +34,13 @@ const SNACKBAR_MSG = {
     STAR: '메일 중요표시에 실패하였습니다.',
     UNSTAR: '메일 중요표시 해제에 실패하였습니다.',
     LOAD: '메일 불러오기에 실패하였습니다.',
-    RECYCLE: '메일 복구를 실패하였습니다.',
+    FOREVER_DELETE: '메일 영구 삭제에 실패하였습니다.',
   },
   SUCCESS: {
     DELETE: '메일을 삭제하였습니다.',
     STAR: '메일 중요표시를 하였습니다.',
     UNSTAR: '메일 중요표시를 해제하였습니다.',
-    RECYCLE: '메일을 복구하였습니다.',
+    FOREVER_DELETE: '메일을 영구 삭제하였습니다.',
   },
 };
 
@@ -52,15 +52,12 @@ const loadNewMails = async (query, dispatch) => {
   dispatch(handleMailsChange({ ...data }));
 };
 
-const updateMail = async (no, props) => {
-  return request.patch(`/mail/${no}`, { props });
-};
-
 const handleAction = {
   [ACTION.STAR]: async ({ mail, openSnackbar }) => {
     try {
       mail.is_important = !mail.is_important;
-      const { isError } = await updateMail(mail.no, { is_important: mail.is_important });
+      const props = { is_important: mail.is_important };
+      const { isError } = await request.patch(`/mail/${mail.no}`, { props });
       if (isError) {
         throw mail.is_important ? SNACKBAR_MSG.ERROR.UNSTAR : SNACKBAR_MSG.ERROR.STAR;
       }
@@ -74,7 +71,8 @@ const handleAction = {
   },
   [ACTION.DELETE]: async ({ mail, dispatch, query, wastebasketNo, openSnackbar }) => {
     try {
-      const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
+      const props = { category_no: wastebasketNo };
+      const { isError } = await request.patch(`/mail/${mail.no}`, { props });
       if (isError) {
         throw SNACKBAR_MSG.ERROR.DELETE;
       }
@@ -84,14 +82,14 @@ const handleAction = {
       openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
     }
   },
-  [ACTION.RECYCLE]: async ({ mail, dispatch, query, openSnackbar }) => {
+  [ACTION.FOREVER_DELETE]: async ({ mail, dispatch, query, openSnackbar }) => {
     try {
-      const { isError } = await updateMail(mail.no, { category_no: mail.prev_category_no });
+      const { isError } = await request.delete(`/mail/${mail.no}`);
       if (isError) {
-        throw SNACKBAR_MSG.ERROR.RECYCLE;
+        throw SNACKBAR_MSG.ERROR.FOREVER_DELETE;
       }
       await loadNewMails(query, dispatch);
-      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.RECYCLE);
+      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.FOREVER_DELETE);
     } catch (errorMessage) {
       openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
     }

--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -25,7 +25,7 @@ const ACTION = {
   STAR: 'star',
   DELETE: 'delete',
   READ: 'read',
-  FOREVER_DELETE: 'foreverDelete',
+  DELETE_FOREVER: 'deleteForever',
 };
 
 const SNACKBAR_MSG = {
@@ -34,13 +34,13 @@ const SNACKBAR_MSG = {
     STAR: '메일 중요표시에 실패하였습니다.',
     UNSTAR: '메일 중요표시 해제에 실패하였습니다.',
     LOAD: '메일 불러오기에 실패하였습니다.',
-    FOREVER_DELETE: '메일 영구 삭제에 실패하였습니다.',
+    DELETE_FOREVER: '메일 영구 삭제에 실패하였습니다.',
   },
   SUCCESS: {
     DELETE: '메일을 삭제하였습니다.',
     STAR: '메일 중요표시를 하였습니다.',
     UNSTAR: '메일 중요표시를 해제하였습니다.',
-    FOREVER_DELETE: '메일을 영구 삭제하였습니다.',
+    DELETE_FOREVER: '메일을 영구 삭제하였습니다.',
   },
 };
 
@@ -82,14 +82,14 @@ const handleAction = {
       openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
     }
   },
-  [ACTION.FOREVER_DELETE]: async ({ mail, dispatch, query, openSnackbar }) => {
+  [ACTION.DELETE_FOREVER]: async ({ mail, dispatch, query, openSnackbar }) => {
     try {
       const { isError } = await request.delete(`/mail/${mail.no}`);
       if (isError) {
-        throw SNACKBAR_MSG.ERROR.FOREVER_DELETE;
+        throw SNACKBAR_MSG.ERROR.DELETE_FOREVER;
       }
       await loadNewMails(query, dispatch);
-      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.FOREVER_DELETE);
+      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE_FOREVER);
     } catch (errorMessage) {
       openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
     }

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Button } from '@material-ui/core';
-import { Email, Send, Delete } from '@material-ui/icons';
+import { Email, Send, Delete, DeleteForever } from '@material-ui/icons';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
 import { handleSnackbarState, setView } from '../../../contexts/reducer';
 import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
@@ -34,17 +34,20 @@ const buttons = [
     key: 'reply',
     name: '답장',
     icon: <Email />,
+    enable: true,
     onClick: () => {},
   },
   {
     key: 'send',
     name: '전달',
     icon: <Send />,
+    enable: true,
     onClick: () => {},
   },
   {
     key: 'delete',
     name: '삭제',
+    enable: true,
     icon: <Delete />,
     onClick: async ({ mail, openSnackbar, wastebasketNo, backToMailArea }) => {
       const props = { category_no: wastebasketNo };
@@ -57,7 +60,17 @@ const buttons = [
       backToMailArea();
     },
   },
+  {
+    key: 'forever_delete',
+    name: '영구삭제',
+    icon: <DeleteForever />,
+    enable: true,
+    onClick: () => {},
+  },
 ];
+
+const deleteButton = buttons.find(button => button.key === 'delete');
+const foreverDeleteButton = buttons.find(button => button.key === 'forever_delete');
 
 const Tools = () => {
   const { state } = useContext(AppStateContext);
@@ -69,17 +82,28 @@ const Tools = () => {
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
   const backToMailArea = () => dispatch(setView(<MailArea />));
 
-  const buttonSet = buttons.map((btn, i) => (
-    <Button
-      variant="contained"
-      color="primary"
-      className={classes.button}
-      startIcon={btn.icon}
-      onClick={btn.onClick.bind(null, { mail, openSnackbar, wastebasketNo, backToMailArea })}
-      key={btn.key}>
-      {btn.name}
-    </Button>
-  ));
+  if (mail.category_no === wastebasketNo) {
+    deleteButton.enable = false;
+    foreverDeleteButton.enable = true;
+  } else {
+    deleteButton.enable = true;
+    foreverDeleteButton.enable = false;
+  }
+
+  const buttonSet = buttons.map(btn => {
+    if (btn.enable)
+      return (
+        <Button
+          variant="contained"
+          color="primary"
+          className={classes.button}
+          startIcon={btn.icon}
+          onClick={btn.onClick.bind(null, { mail, openSnackbar, wastebasketNo, backToMailArea })}
+          key={btn.key}>
+          {btn.name}
+        </Button>
+      );
+  });
 
   return <S.Container>{buttonSet}</S.Container>;
 };

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Button } from '@material-ui/core';
 import { Email, Send, Delete, DeleteForever } from '@material-ui/icons';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
-import { handleSnackbarState, setView } from '../../../contexts/reducer';
+import { handleSnackbarState, setView, handleCategoryClick } from '../../../contexts/reducer';
 import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
 import S from './styled';
 import MailArea from '../../MailArea';
@@ -13,10 +13,12 @@ const WASTEBASKET_NAME = '휴지통';
 const SNACKBAR_MSG = {
   ERROR: {
     DELETE: '메일 삭제에 실패하였습니다.',
+    RECYLCE: '메일 복구에 실패하였습니다.',
     FOREVER_DELETE: '메일 영구 삭제에 실패하였습니다.',
   },
   SUCCESS: {
     DELETE: '메일을 삭제하였습니다.',
+    RECYLCE: '메일을 복구하였습니다.',
     FOREVER_DELETE: '메일을 영구 삭제하였습니다.',
   },
 };
@@ -51,7 +53,7 @@ const buttons = [
     name: '삭제',
     enable: true,
     icon: <Delete />,
-    onClick: async ({ mail, openSnackbar, wastebasketNo, backToMailArea }) => {
+    onClick: async ({ mail, openSnackbar, wastebasketNo, dispatch }) => {
       const props = { category_no: wastebasketNo };
       const { isError } = await request.patch(`/mail/${mail.no}`, { props });
       if (isError) {
@@ -59,7 +61,23 @@ const buttons = [
         return;
       }
       openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE);
-      backToMailArea();
+      dispatch(setView(<MailArea />));
+    },
+  },
+  {
+    key: 'recycle',
+    name: '복구',
+    enable: true,
+    icon: <Delete />,
+    onClick: async ({ mail, openSnackbar, dispatch }) => {
+      const props = { category_no: mail.prev_category_no };
+      const { isError } = await request.patch(`/mail/${mail.no}`, { props });
+      if (isError) {
+        openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.RECYLCE);
+        return;
+      }
+      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.RECYLCE);
+      dispatch(handleCategoryClick(mail.prev_category_no, <MailArea />));
     },
   },
   {
@@ -67,20 +85,21 @@ const buttons = [
     name: '영구삭제',
     icon: <DeleteForever />,
     enable: true,
-    onClick: async ({ mail, openSnackbar, backToMailArea }) => {
+    onClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await request.delete(`/mail/${mail.no}`);
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.FOREVER_DELETE);
         return;
       }
       openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.FOREVER_DELETE);
-      backToMailArea();
+      dispatch(setView(<MailArea />));
     },
   },
 ];
 
 const deleteButton = buttons.find(button => button.key === 'delete');
 const foreverDeleteButton = buttons.find(button => button.key === 'forever_delete');
+const recylceButton = buttons.find(button => button.key === 'recycle');
 
 const Tools = () => {
   const { state } = useContext(AppStateContext);
@@ -90,14 +109,15 @@ const Tools = () => {
   const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
-  const backToMailArea = () => dispatch(setView(<MailArea />));
 
   if (mail.category_no === wastebasketNo) {
     deleteButton.enable = false;
     foreverDeleteButton.enable = true;
+    recylceButton.enable = true;
   } else {
     deleteButton.enable = true;
     foreverDeleteButton.enable = false;
+    recylceButton.enable = false;
   }
 
   const buttonSet = buttons.map(btn => {
@@ -108,7 +128,7 @@ const Tools = () => {
           color="primary"
           className={classes.button}
           startIcon={btn.icon}
-          onClick={btn.onClick.bind(null, { mail, openSnackbar, wastebasketNo, backToMailArea })}
+          onClick={btn.onClick.bind(null, { mail, openSnackbar, wastebasketNo, dispatch })}
           key={btn.key}>
           {btn.name}
         </Button>

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -33,6 +33,14 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const updateMail = async (no, props) => {
+  return request.patch(`/mail/${no}`, { props });
+};
+
+const removeMail = async no => {
+  return request.delete(`/mail/${no}`);
+};
+
 const buttons = [
   {
     key: 'reply',
@@ -54,8 +62,7 @@ const buttons = [
     enable: true,
     icon: <Delete />,
     onClick: async ({ mail, openSnackbar, wastebasketNo, dispatch }) => {
-      const props = { category_no: wastebasketNo };
-      const { isError } = await request.patch(`/mail/${mail.no}`, { props });
+      const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE);
         return;
@@ -70,14 +77,13 @@ const buttons = [
     enable: true,
     icon: <Delete />,
     onClick: async ({ mail, openSnackbar, dispatch }) => {
-      const props = { category_no: mail.prev_category_no };
-      const { isError } = await request.patch(`/mail/${mail.no}`, { props });
+      const { isError } = await updateMail(mail.no, { category_no: mail.prev_category_no });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.RECYLCE);
         return;
       }
       openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.RECYLCE);
-      dispatch(handleCategoryClick(mail.prev_category_no, <MailArea />));
+      dispatch(setView(<MailArea />));
     },
   },
   {
@@ -86,7 +92,7 @@ const buttons = [
     icon: <DeleteForever />,
     enable: true,
     onClick: async ({ mail, openSnackbar, dispatch }) => {
-      const { isError } = await request.delete(`/mail/${mail.no}`);
+      const { isError } = await removeMail(mail.no);
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.FOREVER_DELETE);
         return;

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -20,12 +20,12 @@ const SNACKBAR_MSG = {
   ERROR: {
     DELETE: '메일 삭제에 실패하였습니다.',
     RECYLCE: '메일 복구에 실패하였습니다.',
-    FOREVER_DELETE: '메일 영구 삭제에 실패하였습니다.',
+    DELETE_FOREVER: '메일 영구 삭제에 실패하였습니다.',
   },
   SUCCESS: {
     DELETE: '메일을 삭제하였습니다.',
     RECYLCE: '메일을 복구하였습니다.',
-    FOREVER_DELETE: '메일을 영구 삭제하였습니다.',
+    DELETE_FOREVER: '메일을 영구 삭제하였습니다.',
   },
 };
 
@@ -93,24 +93,24 @@ const buttons = [
     },
   },
   {
-    key: 'forever_delete',
+    key: 'DELETE_FOREVER',
     name: '영구삭제',
     icon: <DeleteForeverIcon />,
     enable: true,
     onClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await removeMail(mail.no);
       if (isError) {
-        openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.FOREVER_DELETE);
+        openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE_FOREVER);
         return;
       }
-      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.FOREVER_DELETE);
+      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE_FOREVER);
       dispatch(setView(<MailArea />));
     },
   },
 ];
 
 const deleteButton = buttons.find(button => button.key === 'delete');
-const foreverDeleteButton = buttons.find(button => button.key === 'forever_delete');
+const deleteForeverButton = buttons.find(button => button.key === 'DELETE_FOREVER');
 const recylceButton = buttons.find(button => button.key === 'recycle');
 
 const Tools = () => {
@@ -124,11 +124,11 @@ const Tools = () => {
 
   if (mail.category_no === wastebasketNo) {
     deleteButton.enable = false;
-    foreverDeleteButton.enable = true;
+    deleteForeverButton.enable = true;
     recylceButton.enable = true;
   } else {
     deleteButton.enable = true;
-    foreverDeleteButton.enable = false;
+    deleteForeverButton.enable = false;
     recylceButton.enable = false;
   }
 

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -12,10 +12,12 @@ import request from '../../../utils/request';
 const WASTEBASKET_NAME = '휴지통';
 const SNACKBAR_MSG = {
   ERROR: {
-    DELETE: '메일 삭제를 실패하였습니다.',
+    DELETE: '메일 삭제에 실패하였습니다.',
+    FOREVER_DELETE: '메일 영구 삭제에 실패하였습니다.',
   },
   SUCCESS: {
     DELETE: '메일을 삭제하였습니다.',
+    FOREVER_DELETE: '메일을 영구 삭제하였습니다.',
   },
 };
 
@@ -65,7 +67,15 @@ const buttons = [
     name: '영구삭제',
     icon: <DeleteForever />,
     enable: true,
-    onClick: () => {},
+    onClick: async ({ mail, openSnackbar, backToMailArea }) => {
+      const { isError } = await request.delete(`/mail/${mail.no}`);
+      if (isError) {
+        openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.FOREVER_DELETE);
+        return;
+      }
+      openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.FOREVER_DELETE);
+      backToMailArea();
+    },
   },
 ];
 

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -1,9 +1,15 @@
 import React, { useContext } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Button } from '@material-ui/core';
-import { Email, Send, Delete, DeleteForever } from '@material-ui/icons';
+import {
+  Email as EmailIcon,
+  Send as SendIcon,
+  Delete as DeleteIcon,
+  Loop as LoopIcon,
+  DeleteForever as DeleteForeverIcon,
+} from '@material-ui/icons';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
-import { handleSnackbarState, setView, handleCategoryClick } from '../../../contexts/reducer';
+import { handleSnackbarState, setView } from '../../../contexts/reducer';
 import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
 import S from './styled';
 import MailArea from '../../MailArea';
@@ -45,14 +51,14 @@ const buttons = [
   {
     key: 'reply',
     name: '답장',
-    icon: <Email />,
+    icon: <EmailIcon />,
     enable: true,
     onClick: () => {},
   },
   {
     key: 'send',
     name: '전달',
-    icon: <Send />,
+    icon: <SendIcon />,
     enable: true,
     onClick: () => {},
   },
@@ -60,7 +66,7 @@ const buttons = [
     key: 'delete',
     name: '삭제',
     enable: true,
-    icon: <Delete />,
+    icon: <DeleteIcon />,
     onClick: async ({ mail, openSnackbar, wastebasketNo, dispatch }) => {
       const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
       if (isError) {
@@ -75,7 +81,7 @@ const buttons = [
     key: 'recycle',
     name: '복구',
     enable: true,
-    icon: <Delete />,
+    icon: <LoopIcon />,
     onClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await updateMail(mail.no, { category_no: mail.prev_category_no });
       if (isError) {
@@ -89,7 +95,7 @@ const buttons = [
   {
     key: 'forever_delete',
     name: '영구삭제',
-    icon: <DeleteForever />,
+    icon: <DeleteForeverIcon />,
     enable: true,
     onClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await removeMail(mail.no);
@@ -134,7 +140,9 @@ const Tools = () => {
           color="primary"
           className={classes.button}
           startIcon={btn.icon}
-          onClick={btn.onClick.bind(null, { mail, openSnackbar, wastebasketNo, dispatch })}
+          onClick={() => {
+            btn.onClick({ mail, openSnackbar, wastebasketNo, dispatch });
+          }}
           key={btn.key}>
           {btn.name}
         </Button>

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState, useEffect } from 'react';
 import moment from 'moment';
 import dynamic from 'next/dynamic';
-import { StarBorder, Star } from '@material-ui/icons';
+import { StarBorder as StarBorderIcon, Star as StarIcon } from '@material-ui/icons';
 import { yellow } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 import * as S from './styled';
@@ -93,9 +93,9 @@ const ReadMail = () => {
         <S.TitleView>
           <S.Subject>
             {is_important ? (
-              <Star className={classes.star} onClick={handleStarClick} />
+              <StarIcon className={classes.star} onClick={handleStarClick} />
             ) : (
-              <StarBorder className={classes.unstar} onClick={handleStarClick} />
+              <StarBorderIcon className={classes.unstar} onClick={handleStarClick} />
             )}
             <h3>{subject || '제목없음'}</h3>
             <div>

--- a/web/components/ReadMail/styled.js
+++ b/web/components/ReadMail/styled.js
@@ -26,6 +26,7 @@ const Subject = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  cursor: pointer;
 
   h3 {
     margin-left: 10px;

--- a/web/utils/request.js
+++ b/web/utils/request.js
@@ -46,8 +46,8 @@ export default {
     return response;
   },
 
-  async delete(url, options = {}) {
-    const fn = () => server.delete(url, { ...options });
+  async delete(url, body, options = {}) {
+    const fn = () => server.delete(url, { data: body, headers: { ...options } });
     const response = await execute(fn);
     return response;
   },


### PR DESCRIPTION
### 무엇을 (What)
1. 체크가 된 mail들은 selected값이 true이므로 이것을 이용하여 category_no를 업데이트하여 휴지통으로 이동될 수 있도록 구현
2. 메일리스트에서 체크박스 또는 버튼으로 영구삭제 기능 구현
3. 기존에 휴지통의 복구 버튼을 영구삭제 버튼으로 교체하고 휴지통에서 메일읽는 화면에 복구와 영구삭제 기능을 추가 

### 왜 그 방법을 선택했는가? (Why)
1. MailArea의 자식으로 Tools 컴포넌트가 있는데 체크박스를 통해 다수의 메일을 삭제하기 위해서는 이 둘의 컴포넌트가 양방향으로 통신할 수 있어야한다. 따라서 context에 메일리스트를 저장해두고 selected 값을 바꿔주는 것을 통해 해당 기능을 구현하였습니다.
2. 1번의 방법과 동일
3. 다수결로 인해 해당 위치에 복구버튼을 영구삭제 버튼으로 교체

### 리뷰어 참고사항

