### PR TITLE
[FE/Refactor] 단일 메일 업데이트/삭제 로직 제거

### DIFF
--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -90,21 +90,21 @@ const buttons = [
   {
     key: 'reply',
     name: '답장',
-    enable: true,
+    visible: true,
     icon: <Email />,
     handleClick: () => {},
   },
   {
     key: 'send',
     name: '전달',
-    enable: true,
+    visible: true,
     icon: <Send />,
     handleClick: () => {},
   },
   {
     key: 'delete',
     name: '삭제',
-    enable: true,
+    visible: true,
     icon: <Delete />,
     handleClick: async ({ selectedMails, dispatch, query, wastebasketNo, openSnackbar }) => {
       try {
@@ -126,7 +126,7 @@ const buttons = [
   {
     key: 'DELETE_FOREVER',
     name: '영구삭제',
-    enable: true,
+    visible: true,
     icon: <DeleteForever />,
     handleClick: async ({ selectedMails, dispatch, query, openSnackbar }) => {
       try {
@@ -153,6 +153,16 @@ const buttons = [
 const deleteButton = buttons.find(button => button.key === 'delete');
 const deleteForeverButton = buttons.find(button => button.key === 'DELETE_FOREVER');
 
+const swapButtonSetView = (categoryNo, wastebasketNo) => {
+  if (categoryNo === wastebasketNo) {
+    deleteButton.enable = false;
+    deleteForeverButton.enable = true;
+  } else {
+    deleteButton.enable = true;
+    deleteForeverButton.enable = false;
+  }
+};
+
 const Tools = () => {
   const classes = useStyles();
   const { state } = useContext(AppStateContext);
@@ -172,17 +182,10 @@ const Tools = () => {
   };
   const handleFilterChange = ({ target: { value } }) => dispatch(handleSortSelect(value));
   const handleCheckAllChange = () => dispatch(handleCheckAllMails(allMailCheckInTools, mails));
-
-  if (category === wastebasketNo) {
-    deleteButton.enable = false;
-    deleteForeverButton.enable = true;
-  } else {
-    deleteButton.enable = true;
-    deleteForeverButton.enable = false;
-  }
+  swapButtonSetView(category, wastebasketNo);
 
   const buttonSet = buttons.map(btn => {
-    return btn.enable ? (
+    return btn.visible ? (
       <Button
         variant="contained"
         color="primary"

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -79,11 +79,11 @@ const loadNewMails = async (query, dispatch) => {
 };
 
 const updateMails = async (nos, props) => {
-  return request.patch(`/mail`, { nos, props });
+  return request.patch('/mail', { nos, props });
 };
 
 const removeMails = async nos => {
-  return request.delete(`/mail`, { nos });
+  return request.delete('/mail', { nos });
 };
 
 const sortItems = SORT_TYPES.map(type => (

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -92,21 +92,21 @@ const buttons = [
     name: '답장',
     enable: true,
     icon: <Email />,
-    onClick: () => {},
+    handleClick: () => {},
   },
   {
     key: 'send',
     name: '전달',
     enable: true,
     icon: <Send />,
-    onClick: () => {},
+    handleClick: () => {},
   },
   {
     key: 'delete',
     name: '삭제',
     enable: true,
     icon: <Delete />,
-    onClick: async ({ selectedMails, dispatch, query, wastebasketNo, openSnackbar }) => {
+    handleClick: async ({ selectedMails, dispatch, query, wastebasketNo, openSnackbar }) => {
       try {
         const nos = selectedMails.map(({ no }) => no);
         const { isError } = await mailRequest.update(nos, { category_no: wastebasketNo });
@@ -128,7 +128,7 @@ const buttons = [
     name: '영구삭제',
     enable: true,
     icon: <DeleteForever />,
-    onClick: async ({ selectedMails, dispatch, query, openSnackbar }) => {
+    handleClick: async ({ selectedMails, dispatch, query, openSnackbar }) => {
       try {
         const nos = selectedMails.map(({ no }) => no);
         const { isError } = await mailRequest.remove(nos);
@@ -162,9 +162,16 @@ const Tools = () => {
   const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
+  const selectedMails = mails.filter(({ selected }) => selected);
+  const paramsToClick = {
+    selectedMails,
+    dispatch,
+    query,
+    openSnackbar,
+    wastebasketNo,
+  };
   const handleFilterChange = ({ target: { value } }) => dispatch(handleSortSelect(value));
   const handleCheckAllChange = () => dispatch(handleCheckAllMails(allMailCheckInTools, mails));
-  const selectedMails = mails.filter(({ selected }) => selected);
 
   if (category === wastebasketNo) {
     deleteButton.enable = false;
@@ -175,27 +182,20 @@ const Tools = () => {
   }
 
   const buttonSet = buttons.map(btn => {
-    if (btn.enable)
-      return (
-        <Button
-          variant="contained"
-          color="primary"
-          className={classes.button}
-          startIcon={btn.icon}
-          disabled={!selectedMails.length}
-          onClick={() =>
-            btn.onClick({
-              selectedMails,
-              dispatch,
-              query,
-              openSnackbar,
-              wastebasketNo,
-            })
-          }
-          key={btn.key}>
-          {btn.name}
-        </Button>
-      );
+    return btn.enable ? (
+      <Button
+        variant="contained"
+        color="primary"
+        className={classes.button}
+        startIcon={btn.icon}
+        disabled={!selectedMails.length}
+        onClick={btn.handleClick.bind(null, paramsToClick)}
+        key={btn.key}>
+        {btn.name}
+      </Button>
+    ) : (
+      ''
+    );
   });
 
   return (

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -20,10 +20,9 @@ import {
   handleMailsChange,
   initCheckerInTools,
   handlePageNumberClick,
-  handleCategoryClick,
 } from '../../../contexts/reducer';
 import getQueryByOptions from '../../../utils/query';
-import request from '../../../utils/request';
+import mailRequest from '../../../utils/mail-request';
 import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
 import MailArea from '..';
 
@@ -67,7 +66,7 @@ const getArrowIcon = sortValue =>
   );
 
 const loadNewMails = async (query, dispatch) => {
-  const { isError, data } = await request.get(`/mail/?${query}`);
+  const { isError, data } = await mailRequest.get(`/mail/?${query}`);
   if (isError) {
     throw SNACKBAR_MSG.ERROR.LOAD;
   }
@@ -76,14 +75,6 @@ const loadNewMails = async (query, dispatch) => {
   if (mails.length === 0) {
     dispatch(handlePageNumberClick(paging.page));
   }
-};
-
-const updateMails = async (nos, props) => {
-  return request.patch('/mail', { nos, props });
-};
-
-const removeMails = async nos => {
-  return request.delete('/mail', { nos });
 };
 
 const sortItems = SORT_TYPES.map(type => (
@@ -118,7 +109,7 @@ const buttons = [
     onClick: async ({ selectedMails, dispatch, query, wastebasketNo, openSnackbar }) => {
       try {
         const nos = selectedMails.map(({ no }) => no);
-        const { isError } = await updateMails(nos, { category_no: wastebasketNo });
+        const { isError } = await mailRequest.update(nos, { category_no: wastebasketNo });
         if (isError) {
           throw SNACKBAR_MSG.ERROR.DELETE;
         }
@@ -140,7 +131,7 @@ const buttons = [
     onClick: async ({ selectedMails, dispatch, query, openSnackbar }) => {
       try {
         const nos = selectedMails.map(({ no }) => no);
-        const { isError } = await removeMails(nos);
+        const { isError } = await mailRequest.remove(nos);
         if (isError) {
           throw SNACKBAR_MSG.ERROR.DELETE_FOREVER;
         }

--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -15,7 +15,7 @@ import useFetch from '../../utils/use-fetch';
 import getQueryByOptions from '../../utils/query';
 import Tools from './Tools';
 import ReadMail from '../ReadMail';
-import request from '../../utils/request';
+import mailRequest from '../../utils/mail-request';
 import { getSnackbarState, SNACKBAR_VARIANT } from '../Snackbar';
 import noMailImage from '../../assets/imgs/no-mail.png';
 import errorHandler from '../../utils/error-handler';
@@ -44,16 +44,8 @@ const SNACKBAR_MSG = {
   },
 };
 
-const updateMail = async (no, props) => {
-  return request.patch('/mail', { nos: [no], props });
-};
-
-const removeMail = async no => {
-  return request.delete('/mail', { nos: [no] });
-};
-
 const loadNewMails = async (query, dispatch) => {
-  const { isError, data } = await request.get(`/mail/?${query}`);
+  const { isError, data } = await mailRequest.get(`/mail/?${query}`);
   if (isError) {
     throw SNACKBAR_MSG.ERROR.LOAD;
   }
@@ -64,7 +56,7 @@ const handleAction = {
   [ACTION.STAR]: async ({ mail, openSnackbar }) => {
     try {
       mail.is_important = !mail.is_important;
-      const { isError } = await updateMail(mail.no, { is_important: mail.is_important });
+      const { isError } = await mailRequest.update(mail.no, { is_important: mail.is_important });
       if (isError) {
         throw mail.is_important ? SNACKBAR_MSG.ERROR.UNSTAR : SNACKBAR_MSG.ERROR.STAR;
       }
@@ -78,7 +70,7 @@ const handleAction = {
   },
   [ACTION.DELETE]: async ({ mail, dispatch, query, wastebasketNo, openSnackbar }) => {
     try {
-      const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
+      const { isError } = await mailRequest.update(mail.no, { category_no: wastebasketNo });
       if (isError) {
         throw SNACKBAR_MSG.ERROR.DELETE;
       }
@@ -90,7 +82,7 @@ const handleAction = {
   },
   [ACTION.DELETE_FOREVER]: async ({ mail, dispatch, query, openSnackbar }) => {
     try {
-      const { isError } = await removeMail(mail.no);
+      const { isError } = await mailRequest.remove(mail.no);
       if (isError) {
         throw SNACKBAR_MSG.ERROR.DELETE_FOREVER;
       }

--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -44,6 +44,14 @@ const SNACKBAR_MSG = {
   },
 };
 
+const updateMail = async (no, props) => {
+  return request.patch('/mail', { nos: [no], props });
+};
+
+const removeMail = async no => {
+  return request.delete('/mail', { nos: [no] });
+};
+
 const loadNewMails = async (query, dispatch) => {
   const { isError, data } = await request.get(`/mail/?${query}`);
   if (isError) {
@@ -56,8 +64,7 @@ const handleAction = {
   [ACTION.STAR]: async ({ mail, openSnackbar }) => {
     try {
       mail.is_important = !mail.is_important;
-      const props = { is_important: mail.is_important };
-      const { isError } = await request.patch(`/mail/${mail.no}`, { props });
+      const { isError } = await updateMail(mail.no, { is_important: mail.is_important });
       if (isError) {
         throw mail.is_important ? SNACKBAR_MSG.ERROR.UNSTAR : SNACKBAR_MSG.ERROR.STAR;
       }
@@ -71,8 +78,7 @@ const handleAction = {
   },
   [ACTION.DELETE]: async ({ mail, dispatch, query, wastebasketNo, openSnackbar }) => {
     try {
-      const props = { category_no: wastebasketNo };
-      const { isError } = await request.patch(`/mail/${mail.no}`, { props });
+      const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
       if (isError) {
         throw SNACKBAR_MSG.ERROR.DELETE;
       }
@@ -84,7 +90,7 @@ const handleAction = {
   },
   [ACTION.DELETE_FOREVER]: async ({ mail, dispatch, query, openSnackbar }) => {
     try {
-      const { isError } = await request.delete(`/mail/${mail.no}`);
+      const { isError } = await removeMail(mail.no);
       if (isError) {
         throw SNACKBAR_MSG.ERROR.DELETE_FOREVER;
       }

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -13,7 +13,7 @@ import { handleSnackbarState, setView } from '../../../contexts/reducer';
 import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
 import S from './styled';
 import MailArea from '../../MailArea';
-import request from '../../../utils/request';
+import mailRequest from '../../../utils/mail-request';
 
 const WASTEBASKET_NAME = '휴지통';
 const SNACKBAR_MSG = {
@@ -39,14 +39,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const updateMail = async (no, props) => {
-  return request.patch('/mail', { nos: [no], props });
-};
-
-const removeMail = async no => {
-  return request.delete('/mail', { nos: [no] });
-};
-
 const buttons = [
   {
     key: 'reply',
@@ -68,7 +60,7 @@ const buttons = [
     enable: true,
     icon: <DeleteIcon />,
     onClick: async ({ mail, openSnackbar, wastebasketNo, dispatch }) => {
-      const { isError } = await updateMail(mail.no, { category_no: wastebasketNo });
+      const { isError } = await mailRequest.update(mail.no, { category_no: wastebasketNo });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE);
         return;
@@ -83,7 +75,7 @@ const buttons = [
     enable: true,
     icon: <LoopIcon />,
     onClick: async ({ mail, openSnackbar, dispatch }) => {
-      const { isError } = await updateMail(mail.no, { category_no: mail.prev_category_no });
+      const { isError } = await mailRequest.update(mail.no, { category_no: mail.prev_category_no });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.RECYLCE);
         return;
@@ -98,7 +90,7 @@ const buttons = [
     icon: <DeleteForeverIcon />,
     enable: true,
     onClick: async ({ mail, openSnackbar, dispatch }) => {
-      const { isError } = await removeMail(mail.no);
+      const { isError } = await mailRequest.remove(mail.no);
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE_FOREVER);
         return;

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -45,21 +45,21 @@ const buttons = [
     name: '답장',
     icon: <EmailIcon />,
     enable: true,
-    onClick: () => {},
+    handleClick: () => {},
   },
   {
     key: 'send',
     name: '전달',
     icon: <SendIcon />,
     enable: true,
-    onClick: () => {},
+    handleClick: () => {},
   },
   {
     key: 'delete',
     name: '삭제',
     enable: true,
     icon: <DeleteIcon />,
-    onClick: async ({ mail, openSnackbar, wastebasketNo, dispatch }) => {
+    handleClick: async ({ mail, openSnackbar, wastebasketNo, dispatch }) => {
       const { isError } = await mailRequest.update(mail.no, { category_no: wastebasketNo });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE);
@@ -74,7 +74,7 @@ const buttons = [
     name: '복구',
     enable: true,
     icon: <LoopIcon />,
-    onClick: async ({ mail, openSnackbar, dispatch }) => {
+    handleClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await mailRequest.update(mail.no, { category_no: mail.prev_category_no });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.RECYLCE);
@@ -89,7 +89,7 @@ const buttons = [
     name: '영구삭제',
     icon: <DeleteForeverIcon />,
     enable: true,
-    onClick: async ({ mail, openSnackbar, dispatch }) => {
+    handleClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await mailRequest.remove(mail.no);
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE_FOREVER);
@@ -113,6 +113,7 @@ const Tools = () => {
   const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
+  const paramsToClick = { mail, openSnackbar, wastebasketNo, dispatch };
 
   if (mail.category_no === wastebasketNo) {
     deleteButton.enable = false;
@@ -125,20 +126,19 @@ const Tools = () => {
   }
 
   const buttonSet = buttons.map(btn => {
-    if (btn.enable)
-      return (
-        <Button
-          variant="contained"
-          color="primary"
-          className={classes.button}
-          startIcon={btn.icon}
-          onClick={() => {
-            btn.onClick({ mail, openSnackbar, wastebasketNo, dispatch });
-          }}
-          key={btn.key}>
-          {btn.name}
-        </Button>
-      );
+    return btn.enable ? (
+      <Button
+        variant="contained"
+        color="primary"
+        className={classes.button}
+        startIcon={btn.icon}
+        onClick={btn.handleClick.bind(null, paramsToClick)}
+        key={btn.key}>
+        {btn.name}
+      </Button>
+    ) : (
+      ''
+    );
   });
 
   return <S.Container>{buttonSet}</S.Container>;

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -40,11 +40,11 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const updateMail = async (no, props) => {
-  return request.patch(`/mail/${no}`, { props });
+  return request.patch('/mail', { nos: [no], props });
 };
 
 const removeMail = async no => {
-  return request.delete(`/mail/${no}`);
+  return request.delete('/mail', { nos: [no] });
 };
 
 const buttons = [

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -44,20 +44,20 @@ const buttons = [
     key: 'reply',
     name: '답장',
     icon: <EmailIcon />,
-    enable: true,
+    visible: true,
     handleClick: () => {},
   },
   {
     key: 'send',
     name: '전달',
     icon: <SendIcon />,
-    enable: true,
+    visible: true,
     handleClick: () => {},
   },
   {
     key: 'delete',
     name: '삭제',
-    enable: true,
+    visible: true,
     icon: <DeleteIcon />,
     handleClick: async ({ mail, openSnackbar, wastebasketNo, dispatch }) => {
       const { isError } = await mailRequest.update(mail.no, { category_no: wastebasketNo });
@@ -72,7 +72,7 @@ const buttons = [
   {
     key: 'recycle',
     name: '복구',
-    enable: true,
+    visible: true,
     icon: <LoopIcon />,
     handleClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await mailRequest.update(mail.no, { category_no: mail.prev_category_no });
@@ -88,7 +88,7 @@ const buttons = [
     key: 'DELETE_FOREVER',
     name: '영구삭제',
     icon: <DeleteForeverIcon />,
-    enable: true,
+    visible: true,
     handleClick: async ({ mail, openSnackbar, dispatch }) => {
       const { isError } = await mailRequest.remove(mail.no);
       if (isError) {
@@ -105,6 +105,18 @@ const deleteButton = buttons.find(button => button.key === 'delete');
 const deleteForeverButton = buttons.find(button => button.key === 'DELETE_FOREVER');
 const recylceButton = buttons.find(button => button.key === 'recycle');
 
+const swapButtonSetView = (categoryNo, wastebasketNo) => {
+  if (categoryNo === wastebasketNo) {
+    deleteButton.enable = false;
+    deleteForeverButton.enable = true;
+    recylceButton.enable = true;
+  } else {
+    deleteButton.enable = true;
+    deleteForeverButton.enable = false;
+    recylceButton.enable = false;
+  }
+};
+
 const Tools = () => {
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
@@ -114,19 +126,10 @@ const Tools = () => {
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
   const paramsToClick = { mail, openSnackbar, wastebasketNo, dispatch };
-
-  if (mail.category_no === wastebasketNo) {
-    deleteButton.enable = false;
-    deleteForeverButton.enable = true;
-    recylceButton.enable = true;
-  } else {
-    deleteButton.enable = true;
-    deleteForeverButton.enable = false;
-    recylceButton.enable = false;
-  }
+  swapButtonSetView(mail.category_no, wastebasketNo);
 
   const buttonSet = buttons.map(btn => {
-    return btn.enable ? (
+    return btn.visible ? (
       <Button
         variant="contained"
         color="primary"

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -9,7 +9,7 @@ import PageMoveButtonArea from './PageMoveButtonArea';
 import { handleSnackbarState, setMail } from '../../contexts/reducer';
 import { AppStateContext, AppDispatchContext } from '../../contexts';
 import FileList from './FileList';
-import request from '../../utils/request';
+import mailRequest from '../../utils/mail-request';
 import { getSnackbarState, SNACKBAR_VARIANT } from '../Snackbar';
 import Tools from './Tools';
 
@@ -44,13 +44,9 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const updateMail = async (no, props) => {
-  return request.patch('/mail', { nos: [no], props });
-};
-
 const loadAttachments = async (mailTemplateNo, setAttachments) => {
   const url = `/mail/template/${mailTemplateNo}/attachments`;
-  const { data } = await request.get(url);
+  const { data } = await mailRequest.get(url);
   setAttachments(data.attachments);
 };
 
@@ -68,11 +64,11 @@ const ReadMail = () => {
 
   useEffect(() => {
     loadAttachments(mailTemplateNo, setAttachments);
-    updateMail(no, { is_read: true });
+    mailRequest.update(no, { is_read: true });
   }, [no, mailTemplateNo]);
 
   const handleStarClick = async () => {
-    const { isError } = await updateMail(no, { is_important: !is_important });
+    const { isError } = await mailRequest.update(no, { is_important: !is_important });
     let message;
     if (isError) {
       message = !is_important ? SNACKBAR_MSG.ERROR.UNSTAR : SNACKBAR_MSG.ERROR.STAR;

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -45,7 +45,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 const updateMail = async (no, props) => {
-  return request.patch(`/mail/${no}`, { props });
+  return request.patch('/mail', { nos: [no], props });
 };
 
 const loadAttachments = async (mailTemplateNo, setAttachments) => {
@@ -72,7 +72,7 @@ const ReadMail = () => {
   }, [no, mailTemplateNo]);
 
   const handleStarClick = async () => {
-    const { isError, data } = await updateMail(no, { is_important: !is_important });
+    const { isError } = await updateMail(no, { is_important: !is_important });
     let message;
     if (isError) {
       message = !is_important ? SNACKBAR_MSG.ERROR.UNSTAR : SNACKBAR_MSG.ERROR.STAR;
@@ -80,9 +80,8 @@ const ReadMail = () => {
       return;
     }
     message = !is_important ? SNACKBAR_MSG.SUCCESS.STAR : SNACKBAR_MSG.SUCCESS.UNSTAR;
-    data.MailTemplate = MailTemplate;
-    data.index = index;
-    dispatch(setMail(data));
+    state.mail.is_important = !is_important;
+    dispatch(setMail(state.mail));
     openSnackbar(SNACKBAR_VARIANT.SUCCESS, message);
   };
 

--- a/web/utils/mail-request.js
+++ b/web/utils/mail-request.js
@@ -1,0 +1,24 @@
+import request from './request';
+
+const convertNumberToArray = no => {
+  if (!Array.isArray(no)) {
+    return [no];
+  }
+  return no;
+};
+
+const update = async (no, props) => {
+  const nos = convertNumberToArray(no);
+  return request.patch('/mail', { nos, props });
+};
+
+const remove = async no => {
+  const nos = convertNumberToArray(no);
+  return request.delete('/mail', { nos });
+};
+
+const get = async url => {
+  return request.get(url);
+};
+
+export default { update, remove, get };

--- a/web/utils/mail-request.js
+++ b/web/utils/mail-request.js
@@ -1,23 +1,18 @@
 import request from './request';
 
-const convertNumberToArray = no => {
-  if (!Array.isArray(no)) {
-    return [no];
-  }
-  return no;
-};
+const convertToArray = no => (Array.isArray(no) ? no : [no]);
 
 const update = async (no, props) => {
-  const nos = convertNumberToArray(no);
+  const nos = convertToArray(no);
   return request.patch('/mail', { nos, props });
 };
 
 const remove = async no => {
-  const nos = convertNumberToArray(no);
+  const nos = convertToArray(no);
   return request.delete('/mail', { nos });
 };
 
-const get = async url => {
+const get = url => {
   return request.get(url);
 };
 


### PR DESCRIPTION
### 무엇을 (What)
1. 기존에는 다수 메일 업데이트/삭제 로직과 단일 메일 업데이트/삭제 로직이 공존하고 있었다. 이를 다수 메일 업데이트/삭제 로직으로만 처리할 수 있도록 변경하였고 각 컴포넌트에 선언된 updateMail()과 removeMail()을 제거하고 utils/mail-request를 만들어서 공통으로 사용

### 왜 그 방법을 선택했는가? (Why)
1. 다수 메일 처리는 배열을 서버로 넘겨주는데 배열에 하나의 값만 넣어서 보내는 것이 곧 단일 메일 처리에 해당한다. 따라서 나누지 말고 다수 메일처리로 모두 처리할 수 있도록 변경.

### 리뷰어 참고사항

