### PR TITLE
[FE] 메일리스트/메일읽기에서 답장 기능 구현

### DIFF
--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -16,7 +16,8 @@ import { handleMailChecked } from '../../../contexts/reducer';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
 import * as S from './styled';
 
-const WASTEBASKET_NAME = '휴지통';
+const TRASH_MAILBOX = '휴지통';
+const SEND_MAILBOX = '보낸메일함';
 
 const useStyles = makeStyles(() => ({
   delete: {
@@ -57,10 +58,11 @@ const MailTemplate = ({ mail, selected, index, categories }) => {
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
   const { is_important, is_read, MailTemplate, reservation_time, category_no } = mail;
-  const { from, subject, createdAt } = MailTemplate;
+  const { from, to, subject, createdAt } = MailTemplate;
   const handleCheckedChange = () => dispatch(handleMailChecked({ mails: state.mails, index }));
   const classes = useStyles();
-  const wastebasketNo = state.categoryNoByName[WASTEBASKET_NAME];
+  const wastebasketNo = state.categoryNoByName[TRASH_MAILBOX];
+  const sendMailboxNo = state.categoryNoByName[SEND_MAILBOX];
 
   let category = '';
   if (state.category === 0) {
@@ -98,7 +100,7 @@ const MailTemplate = ({ mail, selected, index, categories }) => {
           <DeleteIcon className={classes.delete} id={`delete-${index}`} />
         </S.DeleteButton>
       )}
-      <S.From isRead={is_read}>{from}</S.From>
+      <S.FromOrTo isRead={is_read}>{state.category === sendMailboxNo ? to : from}</S.FromOrTo>
       {category}
       <S.Selectable id={`read-${index}`}>
         <S.Title isRead={is_read} id={`read-${index}`}>

--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -16,7 +16,7 @@ import { handleMailChecked } from '../../../contexts/reducer';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
 import * as S from './styled';
 
-const TRASH_MAILBOX = '휴지통';
+const WASTEBASKET_MAILBOX = '휴지통';
 const SEND_MAILBOX = '보낸메일함';
 
 const useStyles = makeStyles(() => ({
@@ -61,7 +61,7 @@ const MailTemplate = ({ mail, selected, index, categories }) => {
   const { from, to, subject, createdAt } = MailTemplate;
   const handleCheckedChange = () => dispatch(handleMailChecked({ mails: state.mails, index }));
   const classes = useStyles();
-  const wastebasketNo = state.categoryNoByName[TRASH_MAILBOX];
+  const wastebasketNo = state.categoryNoByName[WASTEBASKET_MAILBOX];
   const sendMailboxNo = state.categoryNoByName[SEND_MAILBOX];
 
   let category = '';

--- a/web/components/MailArea/MailTemplate/styled.js
+++ b/web/components/MailArea/MailTemplate/styled.js
@@ -35,7 +35,7 @@ const DeleteForeverButton = styled.div`
   margin-right: 10px;
 `;
 
-const From = styled.div`
+const FromOrTo = styled.div`
   flex: 0 0 150px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -92,7 +92,7 @@ export {
   ReadSign,
   DeleteForeverButton,
   DeleteButton,
-  From,
+  FromOrTo,
   Selectable,
   Title,
   Date,

--- a/web/components/MailArea/MailTemplate/styled.js
+++ b/web/components/MailArea/MailTemplate/styled.js
@@ -36,15 +36,11 @@ const DeleteForeverButton = styled.div`
 `;
 
 const FromOrTo = styled.div`
-  flex: 0 0 150px;
+  flex: 0 0 200px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  cursor: pointer;
   color: ${props => (props.isRead ? 'grey' : '#0459C1')};
-  &:hover {
-    text-decoration: underline;
-  }
 `;
 
 const Selectable = styled.div`

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -12,7 +12,6 @@ import {
 } from '@material-ui/core';
 import { ArrowDownward, ArrowUpward, Email, Send, Delete, DeleteForever } from '@material-ui/icons';
 import S from './styled';
-import * as GS from '../../GlobalStyle';
 import { AppDispatchContext, AppStateContext } from '../../../contexts';
 import {
   handleSortSelect,
@@ -125,7 +124,7 @@ const buttons = [
     },
   },
   {
-    key: 'DELETE_FOREVER',
+    key: 'delete_forever',
     name: '영구삭제',
     visible: true,
     icon: <DeleteForever />,
@@ -152,7 +151,7 @@ const buttons = [
 ];
 
 const deleteButton = buttons.find(button => button.key === 'delete');
-const deleteForeverButton = buttons.find(button => button.key === 'DELETE_FOREVER');
+const deleteForeverButton = buttons.find(button => button.key === 'delete_forever');
 
 const swapButtonSetView = (categoryNo, wastebasketNo) => {
   if (categoryNo === wastebasketNo) {

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -28,7 +28,7 @@ import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
 import WriteMail from '../../WriteMail';
 import sessionStorage from '../../../utils/storage';
 
-const TRASH_MAILBOX = '휴지통';
+const WASTEBASKET_MAILBOX = '휴지통';
 
 const SNACKBAR_MSG = {
   ERROR: {
@@ -177,7 +177,7 @@ const Tools = () => {
   const { dispatch } = useContext(AppDispatchContext);
   const { allMailCheckInTools, mails, category, categoryNoByName } = state;
   const query = getQueryByOptions(state);
-  const wastebasketNo = categoryNoByName[TRASH_MAILBOX];
+  const wastebasketNo = categoryNoByName[WASTEBASKET_MAILBOX];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
   const selectedMails = mails.filter(({ selected }) => selected);

--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -20,7 +20,7 @@ import { getSnackbarState, SNACKBAR_VARIANT } from '../Snackbar';
 import noMailImage from '../../assets/imgs/no-mail.png';
 import errorHandler from '../../utils/error-handler';
 
-const TRASH_MAILBOX = '휴지통';
+const WASTEBASKET_MAILBOX = '휴지통';
 const ACTION = {
   STAR: 'star',
   DELETE: 'delete',
@@ -126,7 +126,7 @@ const MailArea = () => {
   }
 
   const { mails, paging, categoryNoByName } = state;
-  const wastebasketNo = categoryNoByName[TRASH_MAILBOX];
+  const wastebasketNo = categoryNoByName[WASTEBASKET_MAILBOX];
   const categories = {};
   Object.entries(categoryNoByName).map(([k, v]) => (categories[v] = k));
 

--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -20,7 +20,7 @@ import { getSnackbarState, SNACKBAR_VARIANT } from '../Snackbar';
 import noMailImage from '../../assets/imgs/no-mail.png';
 import errorHandler from '../../utils/error-handler';
 
-const WASTEBASKET_NAME = '휴지통';
+const TRASH_MAILBOX = '휴지통';
 const ACTION = {
   STAR: 'star',
   DELETE: 'delete',
@@ -126,7 +126,7 @@ const MailArea = () => {
   }
 
   const { mails, paging, categoryNoByName } = state;
-  const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
+  const wastebasketNo = categoryNoByName[TRASH_MAILBOX];
   const categories = {};
   Object.entries(categoryNoByName).map(([k, v]) => (categories[v] = k));
 

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -85,7 +85,7 @@ const buttons = [
     },
   },
   {
-    key: 'DELETE_FOREVER',
+    key: 'delete_forever',
     name: '영구삭제',
     icon: <DeleteForeverIcon />,
     visible: true,
@@ -102,7 +102,7 @@ const buttons = [
 ];
 
 const deleteButton = buttons.find(button => button.key === 'delete');
-const deleteForeverButton = buttons.find(button => button.key === 'DELETE_FOREVER');
+const deleteForeverButton = buttons.find(button => button.key === 'delete_forever');
 const recylceButton = buttons.find(button => button.key === 'recycle');
 
 const swapButtonSetView = (categoryNo, wastebasketNo) => {

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -17,7 +17,7 @@ import mailRequest from '../../../utils/mail-request';
 import WriteMail from '../../WriteMail';
 import sessionStorage from '../../../utils/storage';
 
-const TRASH_MAILBOX = '휴지통';
+const WASTEBASKET_MAILBOX = '휴지통';
 const SNACKBAR_MSG = {
   ERROR: {
     DELETE: '메일 삭제에 실패하였습니다.',
@@ -124,7 +124,7 @@ const Tools = () => {
   const { dispatch } = useContext(AppDispatchContext);
   const classes = useStyles();
   const { mail, categoryNoByName } = state;
-  const wastebasketNo = categoryNoByName[TRASH_MAILBOX];
+  const wastebasketNo = categoryNoByName[WASTEBASKET_MAILBOX];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
   const paramsToClick = { mail, openSnackbar, wastebasketNo, dispatch };

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -15,7 +15,7 @@ import S from './styled';
 import MailArea from '../../MailArea';
 import mailRequest from '../../../utils/mail-request';
 
-const WASTEBASKET_NAME = '휴지통';
+const TRASH_MAILBOX = '휴지통';
 const SNACKBAR_MSG = {
   ERROR: {
     DELETE: '메일 삭제에 실패하였습니다.',
@@ -122,7 +122,7 @@ const Tools = () => {
   const { dispatch } = useContext(AppDispatchContext);
   const classes = useStyles();
   const { mail, categoryNoByName } = state;
-  const wastebasketNo = categoryNoByName[WASTEBASKET_NAME];
+  const wastebasketNo = categoryNoByName[TRASH_MAILBOX];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
   const paramsToClick = { mail, openSnackbar, wastebasketNo, dispatch };

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -14,6 +14,8 @@ import { getSnackbarState, SNACKBAR_VARIANT } from '../../Snackbar';
 import S from './styled';
 import MailArea from '../../MailArea';
 import mailRequest from '../../../utils/mail-request';
+import WriteMail from '../../WriteMail';
+import sessionStorage from '../../../utils/storage';
 
 const TRASH_MAILBOX = '휴지통';
 const SNACKBAR_MSG = {
@@ -21,6 +23,7 @@ const SNACKBAR_MSG = {
     DELETE: '메일 삭제에 실패하였습니다.',
     RECYLCE: '메일 복구에 실패하였습니다.',
     DELETE_FOREVER: '메일 영구 삭제에 실패하였습니다.',
+    REPLY_SELF: '자신의 메일에는 답장할 수 없습니다.',
   },
   SUCCESS: {
     DELETE: '메일을 삭제하였습니다.',
@@ -45,14 +48,13 @@ const buttons = [
     name: '답장',
     icon: <EmailIcon />,
     visible: true,
-    handleClick: () => {},
-  },
-  {
-    key: 'send',
-    name: '전달',
-    icon: <SendIcon />,
-    visible: true,
-    handleClick: () => {},
+    handleClick: async ({ mail, openSnackbar, dispatch }) => {
+      if (mail.MailTemplate.from === sessionStorage.getUser().email) {
+        openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.REPLY_SELF);
+        return;
+      }
+      dispatch(setView(<WriteMail mailToReply={mail} />));
+    },
   },
   {
     key: 'delete',

--- a/web/components/WriteMail/InputSubject/index.js
+++ b/web/components/WriteMail/InputSubject/index.js
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import * as S from './styled';
 import * as WM_S from '../styled';
 import { useDispatchForWM, useStateForWM } from '../ContextProvider';
 import { UPDATE_SUBJECT } from '../ContextProvider/reducer/action-type';
 
-const InputSubject = () => {
+const InputSubject = ({ defaultSubject }) => {
   const { subject } = useStateForWM();
   const dispatch = useDispatchForWM();
 
@@ -18,6 +18,10 @@ const InputSubject = () => {
   const focusHandler = _ => {
     setFlag(!flag);
   };
+
+  useEffect(() => {
+    dispatch({ type: UPDATE_SUBJECT, payload: { subject: `RE: ${defaultSubject}` } });
+  }, []);
 
   return (
     <WM_S.RowWrapper>

--- a/web/components/WriteMail/InputSubject/index.js
+++ b/web/components/WriteMail/InputSubject/index.js
@@ -20,7 +20,10 @@ const InputSubject = ({ defaultSubject }) => {
   };
 
   useEffect(() => {
-    dispatch({ type: UPDATE_SUBJECT, payload: { subject: `RE: ${defaultSubject}` } });
+    dispatch({
+      type: UPDATE_SUBJECT,
+      payload: { subject: defaultSubject ? `RE: ${defaultSubject}` : '' },
+    });
   }, []);
 
   return (

--- a/web/components/WriteMail/index.js
+++ b/web/components/WriteMail/index.js
@@ -9,15 +9,16 @@ import DropZone from './DropZone';
 
 const InputBody = dynamic(import('./InputBody'), { ssr: false });
 
-const WriteMail = () => {
+const WriteMail = ({ mailToReply }) => {
   const [dropZoneVisible, setDropZoneVisible] = useState(false);
+  const { from, subject } = mailToReply.MailTemplate;
 
   return (
     <WriteMailContextProvider>
       <S.WriteArea>
         <Tools dropZoneVisible={dropZoneVisible} setDropZoneVisible={setDropZoneVisible} />
-        <InputReceiver />
-        <InputSubject />
+        <InputReceiver defaultReceiver={from} />
+        <InputSubject defaultSubject={subject} />
         <DropZone visible={dropZoneVisible} />
         <InputBody />
       </S.WriteArea>

--- a/web/components/WriteMail/index.js
+++ b/web/components/WriteMail/index.js
@@ -11,14 +11,13 @@ const InputBody = dynamic(import('./InputBody'), { ssr: false });
 
 const WriteMail = ({ mailToReply }) => {
   const [dropZoneVisible, setDropZoneVisible] = useState(false);
-  const { from, subject } = mailToReply.MailTemplate;
 
   return (
     <WriteMailContextProvider>
       <S.WriteArea>
         <Tools dropZoneVisible={dropZoneVisible} setDropZoneVisible={setDropZoneVisible} />
-        <InputReceiver defaultReceiver={from} />
-        <InputSubject defaultSubject={subject} />
+        <InputReceiver defaultReceiver={mailToReply ? mailToReply.MailTemplate.from : null} />
+        <InputSubject defaultSubject={mailToReply ? mailToReply.MailTemplate.subject : null} />
         <DropZone visible={dropZoneVisible} />
         <InputBody />
       </S.WriteArea>


### PR DESCRIPTION
### 무엇을 (What)
1. 답장 버튼 클릭 시 한 개의 메일인지 from이 누구인지 확인한 후 WriteMail 컴포넌트에 해당 메일의 정보를 넘겨주고 제목과 받는 사람의 default값을 지정하도록 한다.

### 왜 그 방법을 선택했는가? (Why)
1. 답장은 한 사람, 한 사람 소중하게 생각해서 보내야 하며 하나의 메일만 클릭하였을 때 답장을 보낼 수 있다. (네이버와 동일) 그리고 자신한테 답장을 보내는건 이상한 짓이므로 배제하였음.

### 리뷰어 참고사항
내용도 담으려고 했지만 내용을 보여주기 위해서는 WriteMail에서도 TUIViewer가 필요하며 불필요한 태그값을 담아서 보내게 되므로 제거