### PR TITLE
[FE] hofix: 답장 시 보낸 주소에서 이메일만 추출하는 함수 추가

### DIFF
--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -100,16 +100,16 @@ const MailTemplate = ({ mail, selected, index, categories }) => {
           <DeleteIcon className={classes.delete} id={`delete-${index}`} />
         </S.DeleteButton>
       )}
-      <S.FromOrTo isRead={is_read}>{state.category === sendMailboxNo ? to : from}</S.FromOrTo>
+      <S.AddressText isRead={is_read}>{state.category === sendMailboxNo ? to : from}</S.AddressText>
       {category}
       <S.Selectable id={`read-${index}`}>
-        <S.Title isRead={is_read} id={`read-${index}`}>
+        <S.SubjectText isRead={is_read} id={`read-${index}`}>
           {subject || '제목없음'}
-        </S.Title>
-        <S.Date>
+        </S.SubjectText>
+        <S.DateText>
           {getDateOrTime(createdAt)}
-          <S.Text>{reservation_time && '예약'}</S.Text>
-        </S.Date>
+          <S.ReservationText>{reservation_time && '예약'}</S.ReservationText>
+        </S.DateText>
       </S.Selectable>
     </S.Container>
   );

--- a/web/components/MailArea/MailTemplate/styled.js
+++ b/web/components/MailArea/MailTemplate/styled.js
@@ -35,7 +35,7 @@ const DeleteForeverButton = styled.div`
   margin-right: 10px;
 `;
 
-const FromOrTo = styled.div`
+const AddressText = styled.div`
   flex: 0 0 200px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -51,7 +51,7 @@ const Selectable = styled.div`
   flex: 1 1;
 `;
 
-const Title = styled.div`
+const SubjectText = styled.div`
   flex: 1 1;
   margin-left: 15px;
   text-overflow: ellipsis;
@@ -64,14 +64,14 @@ const Title = styled.div`
   }
 `;
 
-const Date = styled.div`
+const DateText = styled.div`
   display: flex;
   font-weight: 600;
   margin: 0 10px;
   color: grey;
 `;
 
-const Text = styled.span`
+const ReservationText = styled.span`
   width: 35px;
   color: #0066ff;
   margin-left: 15px;
@@ -88,10 +88,10 @@ export {
   ReadSign,
   DeleteForeverButton,
   DeleteButton,
-  FromOrTo,
+  AddressText,
   Selectable,
-  Title,
-  Date,
-  Text,
+  SubjectText,
+  DateText,
+  ReservationText,
   CategoryName,
 };

--- a/web/components/MailArea/Paging/index.js
+++ b/web/components/MailArea/Paging/index.js
@@ -37,7 +37,6 @@ const Paging = ({ paging }) => {
   const { page, startPage, totalPage, endPage } = paging;
   const currentIndex = Math.floor(startPage / PAGE_LIST_NUM);
   const { dispatch } = useContext(AppDispatchContext);
-  console.dir(paging);
   const classes = useStyles();
 
   const pagingNumber = getPagingNumbers(startPage, endPage, page);

--- a/web/components/WriteMail/InputReceiver/index.js
+++ b/web/components/WriteMail/InputReceiver/index.js
@@ -6,6 +6,11 @@ import * as SC from '../../../utils/special-characters';
 import { useDispatchForWM, useStateForWM } from '../ContextProvider';
 import { UPDATE_RECEIVERS } from '../ContextProvider/reducer/action-type';
 
+const extractAddress = data => {
+  const address = /<.{3,40}@.{3,40}>/.exec(data);
+  return address ? address[0].slice(1, -1) : data;
+};
+
 const ListOfReceivers = ({ defaultReceiver }) => {
   const { receivers } = useStateForWM();
   const dispatch = useDispatchForWM();
@@ -22,7 +27,7 @@ const ListOfReceivers = ({ defaultReceiver }) => {
     if (defaultReceiver) {
       dispatch({
         type: UPDATE_RECEIVERS,
-        payload: { receivers: [defaultReceiver] },
+        payload: { receivers: [extractAddress(defaultReceiver)] },
       });
     }
   }, [defaultReceiver]);

--- a/web/components/WriteMail/InputSubject/index.js
+++ b/web/components/WriteMail/InputSubject/index.js
@@ -22,7 +22,7 @@ const InputSubject = ({ defaultSubject }) => {
   useEffect(() => {
     dispatch({
       type: UPDATE_SUBJECT,
-      payload: { subject: defaultSubject ? `RE: ${defaultSubject}` : '' },
+      payload: { subject: defaultSubject ? `Re: ${defaultSubject}` : '' },
     });
   }, []);
 


### PR DESCRIPTION
### 무엇을 (What)
1. defaultRecevier을 정규식으로 확인하여 이메일 값만 추출할 수 있도록 extractAddres() 추가

### 왜 그 방법을 선택했는가? (Why)
1. 네이버에서 받은 메일의 경우 보낸 주소가 "배형진 <dkwk1254@naver.com>"이다. 따라서 이메일 주소값만 추출하는 로직이 필요하므로 추가

### 리뷰어 참고사항
MailTemplate의 style component 변수명 변경 
