### PR TITLE
[홍종화]w6_리뷰요청_프론트_쿼리스트링

### DIFF
--- a/review/components/IndexLayout/index.js
+++ b/review/components/IndexLayout/index.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState, useContext } from 'react';
+import Router from 'next/router';
+import * as GS from '../GlobalStyle';
+import Aside from '../Aside';
+import MailArea from '../MailArea';
+import Header from '../Header';
+import Footer from '../Footer';
+import Loading from '../Loading';
+import storage from '../../utils/storage';
+import MessageSnackbar from '../Snackbar';
+import { AppDispatchContext, AppStateContext } from '../../contexts';
+import { setView, handleSnackbarState } from '../../contexts/reducer';
+
+const IndexPageLayout = props => {
+  const { state } = useContext(AppStateContext);
+  const { dispatch } = useContext(AppDispatchContext);
+  const [user, setUser] = useState(null);
+  const { snackbarOpen, snackbarVariant, snackbarContent } = state;
+  const snackbarState = { snackbarOpen, snackbarVariant, snackbarContent };
+
+  useEffect(() => {
+    const userData = storage.getUser();
+    if (!userData) {
+      Router.push('/login');
+    } else {
+      setUser(userData);
+      dispatch(setView(<MailArea />));
+    }
+  }, [dispatch]);
+
+  const messageSnackbarProps = {
+    ...snackbarState,
+    snackbarClose: () => dispatch(handleSnackbarState({ snackbarOpen: false })),
+  };
+
+  const indexPage = (
+    <GS.FlexWrap>
+      <Header />
+      <GS.Content>
+        <MessageSnackbar {...messageSnackbarProps} />
+        <Aside />
+        {props.children}
+      </GS.Content>
+      <Footer />
+    </GS.FlexWrap>
+  );
+  return user ? indexPage : <Loading full={true} />;
+};
+
+export default IndexPageLayout;

--- a/review/pages/index.js
+++ b/review/pages/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import Layout from '../components/IndexLayout';
+import MailArea from '../components/MailArea';
+import WriteMailToMe from '../components/WriteMailToMe';
+import WriteMail from '../components/WriteMail';
+import ReadMail from '../components/ReadMail';
+
+const VIEW_COMPONENT = {
+  'WRITE-TO-ME': <WriteMailToMe />,
+  WRITE: <WriteMail />,
+  READ: <ReadMail />,
+  SEARCH: <MailArea />,
+  LIST: <MailArea />,
+};
+const IndexPage = () => {
+  const router = useRouter();
+  const { query } = router;
+  let { view } = query;
+
+  if (view) {
+    view = view.toUpperCase();
+  }
+  const renderView = VIEW_COMPONENT[view] || <MailArea />;
+
+  return <Layout>{renderView}</Layout>;
+};
+
+export default IndexPage;

--- a/review/utils/url/change-query.js
+++ b/review/utils/url/change-query.js
@@ -1,0 +1,74 @@
+import Router from 'next/router';
+
+const VIEW_STRING = {
+  WRITE: 'write',
+  'WRITE-TO-ME': 'write-to-me',
+  READ: 'read',
+  SEARCH: 'search',
+};
+
+const SORTING_CRITERIA = {
+  datedesc: 'sort=datedesc',
+  dateasc: 'sort=dateasc',
+  subjectdesc: 'sort=subjectdesc',
+  subjectasc: 'sort=subjectasc',
+  fromdesc: 'sort=fromdesc',
+  fromasc: 'sort=fromasc',
+};
+
+const changeView = view => {
+  changeUrlWithoutRunning({ view });
+};
+
+const changeCategory = categoryNo => {
+  changeUrlWithoutRunning({ category: categoryNo });
+};
+
+const getQueryByOptions = ({ category, page, view, mailNo, sort }) => {
+  const queries = [];
+
+  if (category > 0) {
+    queries.push(`category=${category}`);
+  }
+
+  if (page > 0) {
+    queries.push(`page=${page}`);
+  }
+
+  if (view) {
+    queries.push(`view=${view}`);
+  }
+
+  if (view === VIEW_STRING.READ) {
+    queries.push(`mailNo=${mailNo}`);
+  }
+
+  if (SORTING_CRITERIA[sort]) {
+    queries.push(SORTING_CRITERIA[sort]);
+  }
+
+  return queries;
+};
+
+/**
+ * @param {Object} options
+ * @param {Number} options.category
+ * @param {Number} options.page
+ * @param {String} options.view
+ * @param {Number} options.mailNo
+ * @param {String} options.sort
+ * @param {String} path
+ */
+const changeUrlWithoutRunning = (options, path = '/') => {
+  const queries = getQueryByOptions(options);
+  if (queries.length === 0) {
+    return Router.push(path, path, { shallow: true });
+  }
+
+  const nextUrl = queries.join('&');
+  const href = `${path}?${nextUrl}`;
+  const as = href;
+  return Router.push(href, as, { shallow: true });
+};
+
+export { changeUrlWithoutRunning, getQueryByOptions, changeView, VIEW_STRING, changeCategory };


### PR DESCRIPTION
안녕하세요. 리뷰어님

이번 주는 새로운 기능이 아닌, 기존 코드를 수정하는 작업을 진행하고 있습니다.
url Query 값을 활용하여 Query를 만들었어야 하는데, state로 관리하여 history 관리가 전혀 되지 않았습니다. 때문에 이 구조를 걷어내고, query 형식으로 바꾸고 있습니다.
이 작업을 하면서 생긴 궁금증이 두 가지 있습니다.

1. 잘못된 url Query 요청은 어떻게 처리할 것인가입니다.
사용자가 직접적으로 URL Query를 조작하는 경우가 발생할 텐데요. 이때 잘못된 요청을 할 경우 어떻게 처리해야 하는가입니다. 예를 들어 category의 값은 자연수만 사용할 수 있는데, 임의 조작으로 category=qwd와 같이 적었을 때,
- 잘못된 query가 들어가 있음을 알리고, 서버에 요청하지 않는다.
- 잘못된 query를 제거하고 default value로 서버에 요청한다.
두 가지 상황이 고려되는데요. 어느 방식을 선호하시는지 궁금합니다.

프론트에서는 두 번째 방식을 채택하고 있고,
서버에서는 첫 번째 방식을 채택하고 있습니다. 자연수가 아닌 경우 400에러, 값이 없는 경우 default value를 사용하고 있습니다. 권한이 없는 category 요청 시 404를 반환(private을 보장하기 위함)

2. 모두가 작업 중인 페이지, 컴포넌트에 리팩토링 작업이 들어가고 있는데, 이를 어떻게 하면 효율적으로 할 수 있는지 궁금합니다.
메일 서비스를 제공하는 것이 목표이기 때문에, mail page에 팀원 전원이 작업을 하고 있습니다.
작업이 전부 끝나고 리팩토링이 들어가기엔 시간적 여유가 없으며, 점점 바꿔야 할 것이 많아져 더욱 힘든 작업이 될 것이라 판단하여 이번 주부터 시작하게 됐습니다.
당연히 충돌이 발생하겠지만, 어떻게 작업을 하면 충돌을 해결하는 비용을 줄일 수 있을지 궁금합니다.

지금 진행 중인 방식은 기존 소스를 유지하면서 새로운 작업을 추가하는 것인데요.
성능상 비효율적이나, 바뀐 로직으로 발생할 수 있는 에러를 최대한 방지할 수 있다는 것입니다.
이 작업이 완료되면, 비효율적인 소스를 걷어내고, 최적화하는 작업으로 생각하고 있습니다.


