### PR TITLE
[이정환]w6_리뷰요청_로그인여부_판단_HOC_작성

### DIFF
--- a/review/frontend/higher-order-component/with-authentication.js
+++ b/review/frontend/higher-order-component/with-authentication.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Loading from '../components/Loading';
+import { useAuthentication } from '../hook/use-authentication';
+
+const withAuthentication = WrappedComponent => {
+  const containerComponent = () => {
+    const user = useAuthentication();
+
+    return !user ? (
+      <Loading full={true} />
+    ) : (
+      <WrappedComponent name={user.name} sub_email={user.sub_email} email={user.email} />
+    );
+  };
+
+  return containerComponent;
+};
+
+export { withAuthentication };

--- a/review/frontend/hook/use-authentication.js
+++ b/review/frontend/hook/use-authentication.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+import Router from 'next/router';
+import storage from '../utils/storage';
+
+const useAuthentication = () => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const userData = storage.getUser();
+    if (!userData) {
+      Router.push('/login');
+      return;
+    }
+
+    setUser(userData);
+  }, []);
+
+  return user;
+};
+
+export { useAuthentication };

--- a/review/frontend/pages/profile.js
+++ b/review/frontend/pages/profile.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import Profile from '../components/Profile';
+import * as GS from '../components/GlobalStyle';
+import BackButton from '../components/BackButton';
+import { withAuthentication } from '../higher-order-component/with-authentication';
+
+const ProfilePage = ({ name, sub_email, email }) => {
+  return (
+    <GS.FlexRowCenterWrap>
+      <BackButton />
+      <GS.TinyBoard>
+        <Profile name={name} sub_email={sub_email} email={email} />
+      </GS.TinyBoard>
+    </GS.FlexRowCenterWrap>
+  );
+};
+
+export default withAuthentication(ProfilePage);

--- a/review/frontend/pages/profile/pwchange.js
+++ b/review/frontend/pages/profile/pwchange.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import PwChangeForm from '../../components/Forms/PwChangeForm';
+import * as GS from '../../components/GlobalStyle';
+import { withAuthentication } from '../../higher-order-component/with-authentication';
+
+const PwChangePage = () => {
+  return (
+    <GS.FlexRowCenterWrap>
+      <GS.SmallColumnBoard>
+        <PwChangeForm />
+      </GS.SmallColumnBoard>
+    </GS.FlexRowCenterWrap>
+  );
+};
+
+export default withAuthentication(PwChangePage);

--- a/review/frontend/utils/history.js
+++ b/review/frontend/utils/history.js
@@ -1,0 +1,7 @@
+const push = url => {
+  window.location.href = url;
+};
+
+export default {
+  push,
+};

--- a/review/frontend/utils/storage.js
+++ b/review/frontend/utils/storage.js
@@ -1,0 +1,23 @@
+const getUser = () => {
+  const data = window.sessionStorage.getItem('user');
+
+  if (!data) {
+    return null;
+  }
+
+  return JSON.parse(data);
+};
+
+const setUser = user => {
+  window.sessionStorage.setItem('user', JSON.stringify(user));
+};
+
+const clear = () => {
+  window.sessionStorage.clear();
+};
+
+export default {
+  getUser,
+  setUser,
+  clear,
+};


### PR DESCRIPTION
안녕하세요 리뷰어님.

여러 페이지에서 로그인 여부 판단이 필요해서, 공통 로직을 분리하여 HOC 함수를 만들었습니다.

HOC에서는 사용자 정보가 sessionStorage에 있는지 확인하여 
유저 정보가 없을 경우 로그인 페이지로 라우팅을 하며, 
있을 경우 유저 정보를 반환하는 useAuthentication customHook을 사용하였습니다. 
그리고 반환받은 유저 정보를 WrappedComponent에 넘겨주도록 하였습니다.

## 질문사항
1. 로그인 여부에 따라 라우팅을 하는 HOC 함수를 만들어봤는데 현업에서는 로그인이 필요한 페이지에 접속할 경우 로그인 여부에 따라 어떤 식으로 라우팅을 하는지 궁금합니다.

2. 비밀번호 변경 페이지 (pwchange.js)에서는 유저 정보는 필요 없고 로그인 여부만 필요한데 WrappedComponent에 유저 정보를 넘겨주는 HOC을 사용하는 것을 어떻게 생각하시는지 궁금합니다.

3. NextJS의 Router.push를 사용하여 라우팅을 할 경우 사용자가 url을 주소창에 입력할 경우 캐싱 되어 있는 페이지가 사라져 웹 브라우저에서 뒤로 가기 버튼을 눌렀을 경우 주소창의 url만 변경되고 페이지는 변하지 않는 문제점이 있었습니다. 이를 해결하기 위해 window.history.href (history.js의 push 함수)를 통해 라우팅을 해보았는데 제대로 동작은 했었습니다. 해당 방법이 올바른 방법인지, 다른 해결 방법이 있는지 궁금합니다.