### PR TITLE
fix(be): 예약 메일 전송을 위한 transporter 미리 생성

### DIFF
--- a/server/src/libraries/mail-util.js
+++ b/server/src/libraries/mail-util.js
@@ -3,6 +3,19 @@ import uuidv4 from 'uuid/v4';
 import replace from './replace';
 
 const { DEFAULT_DOMAIN_NAME, SMTP_PORT, MAIL_AUTH_USER, MAIL_AUTH_PASS } = process.env;
+const MAX_CONNECTIONS = 1000;
+
+const transporter = nodemailer.createTransport({
+  pool: true,
+  maxConnections: MAX_CONNECTIONS,
+  host: `mail.${DEFAULT_DOMAIN_NAME}`,
+  port: SMTP_PORT,
+  secure: true,
+  auth: {
+    user: MAIL_AUTH_USER,
+    pass: MAIL_AUTH_PASS,
+  },
+});
 
 const getSingleMailData = ({ from, to, subject, text, html, attachments = [] }) => {
   // filename, buffer -> content, mimetype -> contentType
@@ -80,9 +93,6 @@ const createMailTemplateToFindPassword = password => {
 };
 
 const sendMail = data => {
-  const transport = getTransport();
-  const transporter = nodemailer.createTransport(transport);
-
   transporter.sendMail(data);
 };
 


### PR DESCRIPTION
### 무엇을 (What)
1. 메일 전송을 위한 transporter를 미리 생성

### 왜 그 방법을 선택했는가? (Why)
1. 예약 메일 수십개 발송시 too many connection 에러가 발생하여 효율성을 개선하기 위해 transporter 미리 생성
[SMTP server too many connection 에러 해결](https://github.com/nodemailer/nodemailer/issues/699)

2. 메일 전송시 보낸메일함에 메일을 저장하기 위해 imap 연결을 따로 하기 때문에 SMTPS 연결시 사용자 계정으로 접속할 필요없이 루트 계정으로 접속하여 사용해도 문제 없음

### 리뷰어 참고사항
- 또한 dovecot imap에 여러명의 유저가 접속할 경우 발생하는 `Maximum number of connections from user+IP exceeded` 에러를 수정하기 위해 `/etc/dovecot/dovecot.conf` 파일에 max-connection수 설정
```
protocol imap {
  mail_max_userip_connections = 1000
}
```

[Dovecot ignoring maximum number of IMAP connections](https://serverfault.com/questions/385187/dovecot-ignoring-maximum-number-of-imap-connections)
