### PR TITLE
[FE/리팩토링] 전역 state.mail 삭제

### DIFF
--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -9,12 +9,7 @@ import S from './styled';
 import Paging from './Paging';
 import { AppDispatchContext, AppStateContext } from '../../contexts';
 import Loading from '../Loading';
-import {
-  handleMailClick,
-  handleMailsChange,
-  initCheckerInTools,
-  handleSnackbarState,
-} from '../../contexts/reducer';
+import { handleMailsChange, initCheckerInTools, handleSnackbarState } from '../../contexts/reducer';
 import useFetch from '../../utils/use-fetch';
 import Tools from './Tools';
 import mailRequest from '../../utils/mail-request';
@@ -96,10 +91,8 @@ const handleAction = {
       openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
     }
   },
-  [ACTION.READ]: ({ mail, dispatch, index, urlQuery }) => {
-    mail.index = index;
-    dispatch(handleMailClick(mail));
-    changeUrlWithoutRunning({ ...urlQuery, view: 'read', mailNo: mail.no });
+  [ACTION.READ]: ({ mail, index, urlQuery }) => {
+    changeUrlWithoutRunning({ ...urlQuery, view: 'read', mailNo: mail.no, mailIndex: index });
   },
 };
 

--- a/web/components/ReadMail/PageMoveButtonArea/index.js
+++ b/web/components/ReadMail/PageMoveButtonArea/index.js
@@ -5,18 +5,18 @@ import { useRouter } from 'next/router';
 import * as S from './styled';
 import request from '../../../utils/request';
 import { AppStateContext, AppDispatchContext } from '../../../contexts';
-import { setMail, handleMailsChange } from '../../../contexts/reducer';
+import { handleMailsChange } from '../../../contexts/reducer';
 import { getQueryByOptions, changeUrlWithoutRunning } from '../../../utils/url/change-query';
 
-const funcToMove = {
+const actionToMove = {
   prev: {
     move: i => i - 1,
-    isLimit: idx => idx === 0,
+    isNeedNewMails: (idx, paging) => idx === 0 && paging.page > 1,
     setIndex: mails => mails.length,
   },
   next: {
     move: i => i + 1,
-    isLimit: (idx, count) => idx === count - 1,
+    isNeedNewMails: (idx, paging, count) => idx === count - 1 && paging.page < paging.totalPage,
     setIndex: () => -1,
   },
 };
@@ -40,30 +40,35 @@ const PageMoveButtonArea = ({ index }) => {
   const { mails, category, sort, paging } = state;
   const mailCount = mails.length;
 
-  const handleMoveBtnClick = async ({ move, isLimit, setIndex }) => {
+  const handleMoveBtnClick = ({ move, isNeedNewMails, setIndex }) => async () => {
     let newMails = mails;
-    if (isLimit(index, mailCount)) {
-      const query = getQueryByOptions({ category, page: move(paging.page), sort });
+    let movedPage = paging.page;
+    if (isNeedNewMails(index, paging, mailCount)) {
+      movedPage = move(paging.page);
+      const query = getQueryByOptions({ category, page: movedPage, sort });
       newMails = await loadNewMails({ query, dispatch });
       index = setIndex(newMails);
     }
     const mail = newMails[move(index)];
-    mail.index = move(index);
-    dispatch(setMail(mail));
-    changeUrlWithoutRunning({ ...urlQuery, mailNo: mail.no });
+    changeUrlWithoutRunning({
+      ...urlQuery,
+      page: movedPage,
+      mailNo: mail.no,
+      mailIndex: mail.index,
+    });
   };
 
   return (
     <S.Container>
       <IconButton
         disabled={isDisabledPrevBtn(index, paging)}
-        onClick={handleMoveBtnClick.bind(null, funcToMove.prev)}>
+        onClick={handleMoveBtnClick(actionToMove.prev)}>
         <ArrowBack />
       </IconButton>
       <S.PageNumberView>{paging.perPageNum * (paging.page - 1) + index + 1}</S.PageNumberView>
       <IconButton
         disabled={isDisabledNextBtn(index, paging, mailCount)}
-        onClick={handleMoveBtnClick.bind(null, funcToMove.next)}>
+        onClick={handleMoveBtnClick(actionToMove.next)}>
         <ArrowForward />
       </IconButton>
     </S.Container>

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -123,12 +123,12 @@ const swapButtonSetView = (categoryNo, wastebasketNo) => {
   }
 };
 
-const Tools = () => {
+const Tools = ({ mail }) => {
   const classes = useStyles();
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
   const [categoryMenu, setCategoryMenu] = useState(null);
-  const { mail, categoryNoByName, categoryNameByNo, categories } = state;
+  const { categoryNoByName, categoryNameByNo, categories } = state;
   const { query: urlQuery } = useRouter();
   const wastebasketNo = categoryNoByName[WASTEBASKET_MAILBOX];
   const openSnackbar = (variant, message) =>

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -79,11 +79,16 @@ const ReadMail = () => {
     dispatch(handleMailsChange({ ...fetcher.data }));
   }, [fetcher.data, dispatch, query.mailIndex, mail]);
 
-  if (fetcher.loading || !mail) {
+  if (fetcher.loading) {
     return <Loading />;
   }
+
   if (fetcher.error) {
     return errorHandler(fetcher.error);
+  }
+
+  if (!mail) {
+    return <Loading />;
   }
 
   const { is_important, MailTemplate, no, reservation_time, index } = mail;

--- a/web/contexts/reducer.js
+++ b/web/contexts/reducer.js
@@ -2,7 +2,6 @@ const CATEGORY_CLICK = 'CATEGORY_CLICK';
 const PAGE_NUMBER_CLICK = 'PAGE_NUMBER_CLICK';
 const CHANGE_MAILS_DATA = 'CHANGE_MAILS_DATA';
 const CHANGE_CATEGORIES_DATA = 'CHANGE_CATEGORIES_DATA';
-const SET_VIEW = 'SET_VIEW';
 const SORT_SELECT = 'SORT_SELECT';
 const SET_MESSAGE = 'SET_MESSAGE';
 const MAIL_CHECK = 'MAIL_CHECK';
@@ -19,7 +18,6 @@ export const initialState = {
   mails: null,
   mailToReply: null,
   paging: null,
-  view: null,
   sort: 'datedesc',
   message: '',
   allMailCheckInTools: false,
@@ -58,7 +56,7 @@ export const initCheckerInTools = () => {
 };
 
 export const handleCheckAllMails = (allMailCheckInTools, mails) => {
-  mails.map(mail => (mail.selected = !allMailCheckInTools));
+  mails.forEach(mail => (mail.selected = !allMailCheckInTools));
   return {
     type: SELECT_ALL_CHANGE,
     payload: { mails, allMailCheckInTools: !allMailCheckInTools },
@@ -99,10 +97,9 @@ export const handleCategoriesChange = ({ categories }) => {
 
 export const handleMailsChange = ({ mails, paging }) => {
   if (mails) {
-    mails.map((mail, i) => {
+    mails.forEach((mail, i) => {
       mail.selected = false;
       mail.index = i;
-      return mail;
     });
   }
   return {
@@ -139,15 +136,6 @@ export const handlePageNumberClick = page => {
     type: PAGE_NUMBER_CLICK,
     payload: {
       page,
-    },
-  };
-};
-
-export const setView = view => {
-  return {
-    type: SET_VIEW,
-    payload: {
-      view,
     },
   };
 };
@@ -195,8 +183,6 @@ export const reducer = (state = initialState, action) => {
     case MAIL_CHECK:
       return { ...state, ...payload };
     case CHANGE_MAILS_DATA:
-      return { ...state, ...payload };
-    case SET_VIEW:
       return { ...state, ...payload };
     case SORT_SELECT:
       return { ...state, ...payload };

--- a/web/contexts/reducer.js
+++ b/web/contexts/reducer.js
@@ -2,7 +2,6 @@ const CATEGORY_CLICK = 'CATEGORY_CLICK';
 const PAGE_NUMBER_CLICK = 'PAGE_NUMBER_CLICK';
 const CHANGE_MAILS_DATA = 'CHANGE_MAILS_DATA';
 const CHANGE_CATEGORIES_DATA = 'CHANGE_CATEGORIES_DATA';
-const MAIL_CLICK = 'MAIL_CLICK';
 const SET_VIEW = 'SET_VIEW';
 const SORT_SELECT = 'SORT_SELECT';
 const SET_MESSAGE = 'SET_MESSAGE';
@@ -10,7 +9,6 @@ const MAIL_CHECK = 'MAIL_CHECK';
 const SELECT_ALL_CHANGE = 'SELECT_ALL_CHANGE';
 const INIT_CHECKER_IN_TOOLS = 'INIT_CHECKER_IN_TOOLS';
 const SET_SNACKBAR_STATE = 'SET_SNACKBAR_STATE';
-const SET_MAIL = 'SET_MAIL';
 const SET_MAIL_TO_REPLY = 'SET_MAIL_TO_REPLY';
 const INIT_STATE = 'INIT_STATE';
 
@@ -19,7 +17,6 @@ export const initialState = {
   category: 0,
   page: 1,
   mails: null,
-  mail: null,
   mailToReply: null,
   paging: null,
   view: null,
@@ -102,7 +99,11 @@ export const handleCategoriesChange = ({ categories }) => {
 
 export const handleMailsChange = ({ mails, paging }) => {
   if (mails) {
-    mails.map(mail => (mail.selected = false));
+    mails.map((mail, i) => {
+      mail.selected = false;
+      mail.index = i;
+      return mail;
+    });
   }
   return {
     type: CHANGE_MAILS_DATA,
@@ -142,15 +143,6 @@ export const handlePageNumberClick = page => {
   };
 };
 
-export const handleMailClick = mail => {
-  return {
-    type: MAIL_CLICK,
-    payload: {
-      mail,
-    },
-  };
-};
-
 export const setView = view => {
   return {
     type: SET_VIEW,
@@ -165,15 +157,6 @@ export const setMessage = message => {
     type: SET_MESSAGE,
     payload: {
       message,
-    },
-  };
-};
-
-export const setMail = mail => {
-  return {
-    type: SET_MAIL,
-    payload: {
-      mail,
     },
   };
 };
@@ -211,8 +194,6 @@ export const reducer = (state = initialState, action) => {
       return { ...state, ...payload };
     case MAIL_CHECK:
       return { ...state, ...payload };
-    case MAIL_CLICK:
-      return { ...state, ...payload };
     case CHANGE_MAILS_DATA:
       return { ...state, ...payload };
     case SET_VIEW:
@@ -222,8 +203,6 @@ export const reducer = (state = initialState, action) => {
     case SET_MESSAGE:
       return { ...state, ...payload };
     case CHANGE_CATEGORIES_DATA:
-      return { ...state, ...payload };
-    case SET_MAIL:
       return { ...state, ...payload };
     case SET_MAIL_TO_REPLY:
       return { ...state, ...payload };

--- a/web/utils/url/change-query.js
+++ b/web/utils/url/change-query.js
@@ -33,7 +33,7 @@ const getQueryByOptions = ({
 }) => {
   const queries = [];
   const setQueries = (key, value) => {
-    if (value !== undefined) {
+    if (value || value === 0) {
       queries.push(`${key}=${value}`);
     }
   };

--- a/web/utils/url/change-query.js
+++ b/web/utils/url/change-query.js
@@ -29,10 +29,11 @@ const getQueryByOptions = ({
   to,
   searchLevel,
   searchWord,
+  mailIndex,
 }) => {
   const queries = [];
   const setQueries = (key, value) => {
-    if (value) {
+    if (value !== undefined) {
       queries.push(`${key}=${value}`);
     }
   };
@@ -50,6 +51,7 @@ const getQueryByOptions = ({
   setQueries('startDate', startDate);
   setQueries('endDate', endDate);
   setQueries('sort', sort);
+  setQueries('mailIndex', mailIndex);
   return queries.join('&');
 };
 


### PR DESCRIPTION
### 무엇을 (What)
1. 전역 state.mail을 삭제하고 ReadMail에서 mail 변수를 새로 만들어서 상태관리하는 로직으로 변경

### 왜 그 방법을 선택했는가? (Why)
1. url을 통해 화면전환으로 변경 된 후 메일읽기에서 새로고침 시 state.mails 값이 null이 됨. 따라서 메일읽기에서 새로 메일리스트를 서버로부터 로드하여 ReadMail 내에 있는 mail의 상태를 변경하도록 수정

### 리뷰어 참고사항
이 리팩토링을 보면 state.mails 역시 삭제 가능한 부분이 아니냐는 의문이 들 수 있다. 하지만, 이미 state.mails는 많은 컴포넌트에 영향을 미치고 있으며 성능적 이슈도 없기 때문에 리팩토링 우선순위를 미룸