### PR TITLE
[BE] 로그인할 때 IMAP과 DB 메일/메일함 동기화 실패시 에러처리 추가

### DIFF
--- a/server/src/libraries/exception/error-code.js
+++ b/server/src/libraries/exception/error-code.js
@@ -48,6 +48,7 @@ const ERROR_CODE = {
   FAIL_TO_SAVE_MAIL: $(500, '메일을 데이터베이스에 저장하는데 실패하였습니다.', 'MAIL002'),
   MAIL_NOT_FOUND: $(404, '존재하지 않는 메일 입니다.', 'MAIL003'),
   FAIL_TO_MOVE_MAIL: $(400, '메일 이동에 실패하였습니다', 'MAIL004'),
+  FAIL_TO_SYNC_MAIL: $(500, '메일을 동기화하는데 실패하였습니다', 'SYNC001'),
 
   CATEGORY_NOT_FOUND: $(404, '존재하지 않는 카테고리 입니다.', 'CATEGORY001'),
 

--- a/server/src/v1/auth/controller.js
+++ b/server/src/v1/auth/controller.js
@@ -1,6 +1,10 @@
 import status from 'http-status';
 
-const login = (req, res) => {
+const login = (req, res, next) => {
+  if (res.locals.syncErr) {
+    req.logout();
+    return next(res.locals.syncErr);
+  }
   const user = { ...req.user };
 
   delete user.password;


### PR DESCRIPTION
### 무엇을 (What)
1. 로그인할 때 IMAP과 DB 메일/메일함 동기화 실패시 에러처리 추가

### 왜 그 방법을 선택했는가? (Why)
1. 동기화하지 못하면 로그인하지 못하도록 함<br>버그를 유발할 수 있기 때문이었습니다

### 리뷰어 참고사항

