### PR TITLE
Hoxfix(fe/mail-area): headTitle에 undefined 뜨는 에러 수정

### DIFF
--- a/web/components/MailArea/index.js
+++ b/web/components/MailArea/index.js
@@ -140,7 +140,7 @@ const MailArea = () => {
     return errorHandler(fetchingMailData.error);
   }
 
-  const { mails, paging, categoryNoByName, category, categoryNameByNo } = state;
+  const { mails, paging, categoryNoByName, categoryNameByNo } = state;
   if (!categoryNoByName || !mails) {
     return <Loading />;
   }
@@ -165,8 +165,9 @@ const MailArea = () => {
     }
   };
 
-  const categoryName = category === 0 ? '전체메일함' : categoryNameByNo[category];
-  const title = `${categoryName} (${paging.page})`;
+  const categoryNo = +urlQuery.category || 0;
+  const categoryName = categoryNo === 0 ? '전체메일함' : categoryNameByNo[categoryNo];
+  const title = `${categoryName} (${paging.totalCount})`;
   return (
     <S.MailArea>
       <HeadTitle title={title} />


### PR DESCRIPTION
### 무엇을 (What)
1. rotuer.query.category 사용

### 왜 그 방법을 선택했는가? (Why)
1. 이전에 쓰던 state.category를 지웠으므로 rotuer.query.category를 사용

### 리뷰어 참고사항

