### PR TITLE
perPageNum이 변경된 후 이전/다음 메일 보기 버그 수정 #439

### DIFF
--- a/web/components/Aside/index.js
+++ b/web/components/Aside/index.js
@@ -65,6 +65,7 @@ const [ADD, MODIFY, DELETE] = [0, 1, 2];
 
 const Aside = () => {
   const classes = useStyles();
+  const { query } = useRouter();
   const [mailboxFolderOpen, setMailboxFolderOpen] = useState(true);
   const [dialogOkButtonDisableState, setDialogOkButtonDisableState] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -72,9 +73,7 @@ const Aside = () => {
   const [dialogTextFieldState, setDialogTextFieldState] = useState('');
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
-  const router = useRouter();
-  const { query } = router;
-  const queryCategory = Number(router.query.category) || 0;
+  const queryCategory = Number(query.category) || 0;
 
   const fetchingCategories = useFetch(URL);
 

--- a/web/components/MailArea/MailTemplate/index.js
+++ b/web/components/MailArea/MailTemplate/index.js
@@ -55,13 +55,13 @@ const getDateOrTime = createdAt => {
 };
 
 const MailTemplate = ({ mail, selected, index, categoryNo }) => {
+  const classes = useStyles();
   const { state } = useContext(AppStateContext);
   const { categoryNameByNo } = state;
   const { dispatch } = useContext(AppDispatchContext);
   const { is_important, is_read, reservation_time, category_no, MailTemplate: mailTemplate } = mail;
   const { from, to, subject, createdAt } = mailTemplate;
   const handleCheckedChange = () => dispatch(handleMailChecked({ mails: state.mails, index }));
-  const classes = useStyles();
   const wastebasketNo = state.categoryNoByName[WASTEBASKET_MAILBOX];
   const sendMailboxNo = state.categoryNoByName[SEND_MAILBOX];
   let category = '';

--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -85,7 +85,7 @@ const getArrowIcon = sortValue =>
     <ArrowDownwardIcon fontSize={'small'} />
   );
 
-const loadNewMails = async (url, dispatch) => {
+const loadNewMails = async (query, dispatch, url) => {
   const { isError, data } = await mailRequest.get(url);
   if (isError) {
     throw SNACKBAR_MSG.ERROR.LOAD;
@@ -93,7 +93,7 @@ const loadNewMails = async (url, dispatch) => {
   dispatch(handleMailsChange({ ...data }));
   const { mails, paging } = data;
   if (mails.length === 0 && paging.page !== 1) {
-    changeUrlWithoutRunning({ page: paging.page });
+    changeUrlWithoutRunning({ ...query, page: paging.page });
   }
 };
 
@@ -131,14 +131,14 @@ const buttons = [
     name: '삭제',
     visible: true,
     icon: <DeleteIcon />,
-    handleClick: async ({ selectedMails, dispatch, wastebasketNo, openSnackbar, url }) => {
+    handleClick: async ({ selectedMails, dispatch, wastebasketNo, openSnackbar, query, url }) => {
       try {
         const nos = selectedMails.map(({ no }) => no);
         const { isError } = await mailRequest.update(nos, { category_no: wastebasketNo });
         if (isError) {
           throw SNACKBAR_MSG.ERROR.DELETE;
         }
-        await loadNewMails(url, dispatch);
+        await loadNewMails(query, dispatch, url);
         openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE(selectedMails.length));
       } catch (errorMessage) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, errorMessage);
@@ -153,14 +153,14 @@ const buttons = [
     name: '영구삭제',
     visible: true,
     icon: <DeleteForeverIcon />,
-    handleClick: async ({ selectedMails, dispatch, openSnackbar, url }) => {
+    handleClick: async ({ selectedMails, dispatch, openSnackbar, query, url }) => {
       try {
         const nos = selectedMails.map(({ no }) => no);
         const { isError } = await mailRequest.remove(nos);
         if (isError) {
           throw SNACKBAR_MSG.ERROR.DELETE_FOREVER;
         }
-        await loadNewMails(url, dispatch);
+        await loadNewMails(query, dispatch, url);
         openSnackbar(
           SNACKBAR_VARIANT.SUCCESS,
           SNACKBAR_MSG.SUCCESS.DELETE_FOREVER(selectedMails.length),
@@ -197,14 +197,7 @@ const Tools = () => {
   const requestPath = getRequestPathByQuery(query);
   const url = `${requestPath}?${queryString}`;
   const [categoryMenu, setCategoryMenu] = useState(null);
-  const {
-    allMailCheckInTools,
-    mails,
-    category,
-    categoryNoByName,
-    categories,
-    categoryNameByNo,
-  } = state;
+  const { allMailCheckInTools, mails, categoryNoByName, categories, categoryNameByNo } = state;
   const wastebasketNo = categoryNoByName[WASTEBASKET_MAILBOX];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
@@ -214,6 +207,7 @@ const Tools = () => {
     dispatch,
     openSnackbar,
     wastebasketNo,
+    query,
     url,
   };
 
@@ -248,7 +242,7 @@ const Tools = () => {
     }
   };
 
-  swapButtonSetView(category, wastebasketNo);
+  swapButtonSetView(+query.category, wastebasketNo);
 
   const buttonSet = buttons.map(btn => {
     return btn.visible ? (

--- a/web/components/ReadMail/PageMoveButtonArea/index.js
+++ b/web/components/ReadMail/PageMoveButtonArea/index.js
@@ -55,7 +55,6 @@ const PageMoveButtonArea = ({ index }) => {
       newMails = await loadNewMails(url, dispatch);
       index = setIndex(newMails);
     }
-    console.log(newMails);
     const mail = newMails[move(index)];
     changeUrlWithoutRunning({
       ...query,

--- a/web/components/ReadMail/Tools/index.js
+++ b/web/components/ReadMail/Tools/index.js
@@ -65,14 +65,14 @@ const buttons = [
     name: '삭제',
     visible: true,
     icon: <DeleteIcon />,
-    handleClick: async ({ mail, openSnackbar, wastebasketNo, urlQuery }) => {
+    handleClick: async ({ mail, openSnackbar, wastebasketNo, query }) => {
       const { isError } = await mailRequest.update(mail.no, { category_no: wastebasketNo });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE);
         return;
       }
       openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE);
-      changeUrlWithoutRunning({ ...urlQuery, view: 'list' });
+      changeUrlWithoutRunning({ ...query, view: 'list' });
     },
   },
   {
@@ -80,14 +80,14 @@ const buttons = [
     name: '복구',
     visible: true,
     icon: <LoopIcon />,
-    handleClick: async ({ mail, openSnackbar, urlQuery }) => {
+    handleClick: async ({ mail, openSnackbar, query }) => {
       const { isError } = await mailRequest.update(mail.no, { category_no: mail.prev_category_no });
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.RECYLCE);
         return;
       }
       openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.RECYLCE);
-      changeUrlWithoutRunning({ ...urlQuery, view: 'list' });
+      changeUrlWithoutRunning({ ...query, view: 'list' });
     },
   },
   {
@@ -95,14 +95,14 @@ const buttons = [
     name: '영구삭제',
     icon: <DeleteForeverIcon />,
     visible: true,
-    handleClick: async ({ mail, openSnackbar, urlQuery }) => {
+    handleClick: async ({ mail, openSnackbar, query }) => {
       const { isError } = await mailRequest.remove(mail.no);
       if (isError) {
         openSnackbar(SNACKBAR_VARIANT.ERROR, SNACKBAR_MSG.ERROR.DELETE_FOREVER);
         return;
       }
       openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE_FOREVER);
-      changeUrlWithoutRunning({ ...urlQuery, view: 'list' });
+      changeUrlWithoutRunning({ ...query, view: 'list' });
     },
   },
 ];
@@ -125,15 +125,15 @@ const swapButtonSetView = (categoryNo, wastebasketNo) => {
 
 const Tools = ({ mail }) => {
   const classes = useStyles();
+  const { query } = useRouter();
   const { state } = useContext(AppStateContext);
   const { dispatch } = useContext(AppDispatchContext);
   const [categoryMenu, setCategoryMenu] = useState(null);
   const { categoryNoByName, categoryNameByNo, categories } = state;
-  const { query: urlQuery } = useRouter();
   const wastebasketNo = categoryNoByName[WASTEBASKET_MAILBOX];
   const openSnackbar = (variant, message) =>
     dispatch(handleSnackbarState(getSnackbarState(variant, message)));
-  const paramsToClick = { mail, openSnackbar, wastebasketNo, dispatch, urlQuery };
+  const paramsToClick = { mail, openSnackbar, wastebasketNo, dispatch, query };
 
   const handleCategoryMenuItemClick = async e => {
     const categoryNoToMove = e.currentTarget.value;
@@ -146,7 +146,7 @@ const Tools = ({ mail }) => {
       SNACKBAR_VARIANT.SUCCESS,
       SNACKBAR_MSG.SUCCESS.MOVE(categoryNameByNo[categoryNoToMove]),
     );
-    changeUrlWithoutRunning({ ...urlQuery, view: 'list' });
+    changeUrlWithoutRunning({ ...query, view: 'list' });
   };
 
   swapButtonSetView(mail.category_no, wastebasketNo);

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -64,8 +64,8 @@ const ReadMail = () => {
   const [attachments, setAttachments] = useState(null);
   const queryString = getQueryByOptions(query);
   const requestPath = getRequestPathByQuery(query);
-  const URL = `${requestPath}?${queryString}`;
-  const fetcher = useFetch(URL);
+  const url = `${requestPath}?${queryString}`;
+  const fetcher = useFetch(url);
 
   useEffect(() => {
     if (!fetcher.data) {


### PR DESCRIPTION
### 무엇을 (What)
1. 이전/다음 버튼 눌렀을 때도 MailArea에서 요청한 url의 형태를 그대로 사용

### 왜 그 방법을 선택했는가? (Why)
1. 이전/다음 메일을 읽을 때 순서를 검색, 정렬된 순서로 읽을 수 있기 위해

### 리뷰어 참고사항
urlQuery 마음에 안들어서 다 지움.
urlQuery -> query (router destructing)
query -> queryString