### PR TITLE
[BE] 전송한 예약 메일을 반환하지 않도록 하여 응답 속도 개선

### DIFF
--- a/server/src/v1/admin/mail/controller.js
+++ b/server/src/v1/admin/mail/controller.js
@@ -1,15 +1,14 @@
+import status from 'http-status';
 import service from './service';
 
 const sendReservationMails = async (req, res, next) => {
-  let mails;
-
   try {
-    mails = await service.handleReservationMails();
+    await service.handleReservationMails();
   } catch (error) {
     return next(error);
   }
 
-  return res.json({ mails });
+  return res.status(status.NO_CONTENT).end();
 };
 
 export default {

--- a/server/src/v1/admin/mail/service.js
+++ b/server/src/v1/admin/mail/service.js
@@ -41,22 +41,16 @@ const sendReservationMail = async (user, mail) => {
 
   mail.reservation_time = null;
   await mail.save();
-
-  return mail;
 };
 
 const sendReservationMailsOfOwner = async (owner, mails) => {
   const user = await DB.User.findByPk(owner, { raw: true });
-  const successMails = [];
 
   user.password = aesDecrypt(user.imap_password);
 
   for (const mail of mails) {
-    const sentMail = await sendReservationMail(user, mail);
-    successMails.push(sentMail);
+    await sendReservationMail(user, mail);
   }
-
-  return successMails;
 };
 
 const handleReservationMails = async () => {
@@ -65,7 +59,6 @@ const handleReservationMails = async () => {
 
   const mailsFromDB = await DB.Mail.findAllPastReservationMailByDate(date);
   const mailsPerUser = {};
-  const sentMailsPromises = [];
 
   for (const mail of mailsFromDB) {
     if (!mailsPerUser[mail.owner]) {
@@ -75,11 +68,8 @@ const handleReservationMails = async () => {
   }
 
   for (const [owner, mails] of Object.entries(mailsPerUser)) {
-    sentMailsPromises.push(sendReservationMailsOfOwner(owner, mails));
+    sendReservationMailsOfOwner(owner, mails);
   }
-
-  const successMails = await Promise.all(sentMailsPromises);
-  return successMails;
 };
 
 export default {

--- a/server/test/admin/mail/api.spec.js
+++ b/server/test/admin/mail/api.spec.js
@@ -20,10 +20,10 @@ describe('예약 메일 보내기 API는...', () => {
       .expect(404, done);
   });
 
-  it('# 올바른 key 값을 넘겨줄 경우 상태코드는 200이다.', done => {
+  it('# 올바른 key 값을 넘겨줄 경우 상태코드는 204이다.', done => {
     request(app)
       .post('/admin/mail')
       .send({ key: ADMIN_KEY })
-      .expect(200, done);
+      .expect(204, done);
   });
 });


### PR DESCRIPTION
### 무엇을 (What)
1. 기존 promise.all을 제거하여 수행결과를 받아오지 않도록 하도록 함

### 왜 그 방법을 선택했는가? (Why)
1. 전송한 예약 메일을 반환하지 않도록 하여 응답 속도 개선

### 리뷰어 참고사항

