### PR TITLE
[BE] imap과 sync맞추는 부분에서 get db mails 함수 for문 하나 줄임

### DIFF
--- a/server/src/database/models/mail.js
+++ b/server/src/database/models/mail.js
@@ -162,7 +162,7 @@ const model = (sequelize, DataTypes) => {
     );
   };
 
-  Mail.findAllNonResultvation = (user_no, category_name) => {
+  Mail.findAllNonReservation = (user_no, category_names) => {
     return Mail.findAll({
       attributes: ['no', 'owner', 'category_no', 'prev_category_no', 'message_id', 'Category.name'],
       where: {
@@ -177,7 +177,9 @@ const model = (sequelize, DataTypes) => {
           model: sequelize.models.Category,
           where: {
             user_no,
-            name: category_name,
+            name: {
+              [Op.in]: category_names,
+            },
           },
         },
       ],

--- a/server/src/middlewares/sync-with-imap.js
+++ b/server/src/middlewares/sync-with-imap.js
@@ -8,13 +8,10 @@ const { NODE_ENV } = process.env;
 const getDBMails = async (imapMessageIds, userNo) => {
   const dbMails = {};
   const mailBoxNames = Object.keys(imapMessageIds);
-  for (const mailBoxName of mailBoxNames) {
-    // eslint-disable-next-line no-await-in-loop
-    const userMails = await DB.Mail.findAllNonResultvation(userNo, mailBoxName);
-    userMails.forEach(userMail => {
-      dbMails[userMail.message_id] = userMail;
-    });
-  }
+  const userMails = await DB.Mail.findAllNonReservation(userNo, mailBoxNames);
+  userMails.forEach(userMail => {
+    dbMails[userMail.message_id] = userMail;
+  });
   return dbMails;
 };
 


### PR DESCRIPTION
### 무엇을 (What)
1. imap과 sync맞추는 부분에서 get db mails 함수 for문 하나 줄임
2. 정환이의 resultVation 수정

### 왜 그 방법을 선택했는가? (Why)
1. `Op.or`와 `Op.in`이 있었는데, `Op.in`의 연산 결과가 더 빠르기에 선택함

### 리뷰어 참고사항

