### PR TITLE
[BE] 메일 카테고리 변경 시 imap 연동

### DIFF
--- a/server/src/database/models/category.js
+++ b/server/src/database/models/category.js
@@ -1,3 +1,5 @@
+import { Op } from 'sequelize';
+
 const model = (sequelize, DataTypes) => {
   const Category = sequelize.define(
     'Category',
@@ -31,6 +33,17 @@ const model = (sequelize, DataTypes) => {
       collate: 'utf8_general_ci',
     },
   );
+
+  Category.findAllByPk = nos => {
+    return Category.findAll({
+      where: {
+        no: {
+          [Op.in]: nos,
+        },
+      },
+      raw: true,
+    });
+  };
 
   Category.findOneByUserNoAndName = (user_no, name) => {
     return Category.findOne({

--- a/server/src/database/models/mail.js
+++ b/server/src/database/models/mail.js
@@ -110,11 +110,13 @@ const model = (sequelize, DataTypes) => {
     });
   };
 
-  Mail.findOneByNoAndUserNo = (no, userNo) => {
-    return Mail.findOne({
+  Mail.findAllByNosAndUserNo = (nos, userNo) => {
+    return Mail.findAll({
       where: {
         owner: userNo,
-        no,
+        no: {
+          [Op.in]: nos,
+        },
       },
       include: [
         {

--- a/server/src/database/models/mail.js
+++ b/server/src/database/models/mail.js
@@ -125,6 +125,7 @@ const model = (sequelize, DataTypes) => {
           model: sequelize.models.MailTemplate,
         },
       ],
+      raw: true,
     });
   };
 

--- a/server/src/v1/mail/controller.js
+++ b/server/src/v1/mail/controller.js
@@ -76,12 +76,11 @@ const write = async (req, res, next) => {
 
 const update = async (req, res, next) => {
   const { nos, props } = req.body;
-  const userNo = req.user.no;
 
   try {
     validateNos(nos);
     validateProps(props);
-    const result = await service.updateMails(nos, props, userNo);
+    const result = await service.updateMails(nos, props, req.user);
     return res.json(result);
   } catch (err) {
     return next(err);

--- a/server/src/v1/mail/service.js
+++ b/server/src/v1/mail/service.js
@@ -178,7 +178,7 @@ const createMessageIdsOfMailbox = async mails => {
 };
 
 const moveMailInInfra = async (mails, props, user) => {
-  if (!props.hasOwnProperty('category_no') || NODE_ENV === 'test') {
+  if (!props.hasOwnProperty('category_no')) {
     return;
   }
 
@@ -208,8 +208,10 @@ const updateMails = async (nos, props, user) => {
   nos = removeDuplicatedNo(nos);
   const mails = await checkOwnerHasMails(nos, user.no);
   await checkCategoryOfMail(mails[0], props);
-  hasMessageIdAllMails(mails);
-  moveMailInInfra(mails, props, user);
+  if (NODE_ENV !== 'test') {
+    hasMessageIdAllMails(mails);
+    moveMailInInfra(mails, props, user);
+  }
   const [updatedCount] = await DB.Mail.updateAllByNosAndProps(nos, props);
   return updatedCount === nos.length;
 };

--- a/server/test/mail/service.spec.js
+++ b/server/test/mail/service.spec.js
@@ -163,7 +163,7 @@ describe('Mail Service Test', () => {
     it('# 1,4,7,10번 메일의 category_no를 4로 변경', async () => {
       const nos = [1, 4, 7, 10];
       const props = { category_no: 4 };
-      const result = await service.updateMails(nos, props, 1);
+      const result = await service.updateMails(nos, props, { no: 1 });
       result.should.be.eql(true);
     });
 
@@ -171,7 +171,7 @@ describe('Mail Service Test', () => {
       const nos = [1, 4, -1, 10];
       const props = { category_no: 3 };
       try {
-        await service.updateMails(nos, props, 1);
+        await service.updateMails(nos, props, { no: 1 });
       } catch (error) {
         const { errorCode } = error;
         errorCode.should.be.eql(ERROR_CODE.MAIL_NOT_FOUND);
@@ -181,7 +181,7 @@ describe('Mail Service Test', () => {
     it('# 1,1,1,1번 메일의 category_no를 4로 변경하면 1개만 변경', async () => {
       const nos = [1, 1, 1, 1];
       const props = { category_no: 4 };
-      const result = await service.updateMails(nos, props, 1);
+      const result = await service.updateMails(nos, props, { no: 1 });
       result.should.be.eql(true);
     });
 
@@ -189,7 +189,7 @@ describe('Mail Service Test', () => {
       const nos = [99999, 100001];
       const props = { category_no: 3 };
       try {
-        await service.updateMails(nos, props, 1);
+        await service.updateMails(nos, props, { no: 1 });
       } catch (error) {
         const { errorCode } = error;
         errorCode.should.be.eql(ERROR_CODE.MAIL_NOT_FOUND);


### PR DESCRIPTION
### 무엇을 (What)
1. mail의 message_id가 있는지 확인(hasMessageIdAllMails)하고 imap의 moveMail()을 통해 imap 연동

### 왜 그 방법을 선택했는가? (Why)
1. message-id가 없으면 imap 연동이 불가능하기 때문에 확인

### 리뷰어 참고사항
더 이상 message-id가 없는 메일을 업데이트하면 에러 메시지 출력됨 
