### PR TITLE
[BE] 예약 메일 전송 API의 return을 try문 안으로 넣음, 변수명 수정

### DIFF
--- a/server/src/v1/admin/mail/controller.js
+++ b/server/src/v1/admin/mail/controller.js
@@ -4,11 +4,10 @@ import service from './service';
 const sendReservationMails = async (req, res, next) => {
   try {
     await service.handleReservationMails();
+    return res.status(status.NO_CONTENT).end();
   } catch (error) {
     return next(error);
   }
-
-  return res.status(status.NO_CONTENT).end();
 };
 
 export default {

--- a/server/src/v1/admin/mail/service.js
+++ b/server/src/v1/admin/mail/service.js
@@ -29,8 +29,8 @@ const sendReservationMail = async (user, mail) => {
   const { from, to, subject, text, Attachments } = MailTemplate;
   const mailboxName = SENT_MAILBOX_NAME;
 
-  const promises = Attachments.map(attachment => getFileNameAndBufferFromAttachment(attachment));
-  const attachments = await Promise.all(promises);
+  const loadTasks = Attachments.map(attachment => getFileNameAndBufferFromAttachment(attachment));
+  const attachments = await Promise.all(loadTasks);
 
   const mailContents = U.getSingleMailData({ from, to, subject, text, attachments });
   mailContents.date = reservation_time;

--- a/server/src/v1/admin/mail/service.js
+++ b/server/src/v1/admin/mail/service.js
@@ -12,16 +12,14 @@ const AVAILABLE_TIME = 10;
 
 const SENT_MAILBOX_NAME = '보낸메일함';
 
-const getFileNameAndBufferFromAttachment = async ({ url, name }) => {
+const getFileNameAndBufferFromAttachment = ({ url, name }) => {
   const stream = getStream(url);
 
-  const buffer = await new Promise(resolve => {
-    stream.on('data', data => {
-      resolve(data);
+  return new Promise(resolve => {
+    stream.on('data', buffer => {
+      resolve({ buffer, originalname: name });
     });
   });
-
-  return { buffer, originalname: name };
 };
 
 const sendReservationMail = async (user, mail) => {
@@ -29,8 +27,8 @@ const sendReservationMail = async (user, mail) => {
   const { from, to, subject, text, Attachments } = MailTemplate;
   const mailboxName = SENT_MAILBOX_NAME;
 
-  const loadTasks = Attachments.map(attachment => getFileNameAndBufferFromAttachment(attachment));
-  const attachments = await Promise.all(loadTasks);
+  const tasks = Attachments.map(attachment => getFileNameAndBufferFromAttachment(attachment));
+  const attachments = await Promise.all(tasks);
 
   const mailContents = U.getSingleMailData({ from, to, subject, text, attachments });
   mailContents.date = reservation_time;


### PR DESCRIPTION
### 무엇을 (What)
1. 예약 메일 전송 API의 return을 try문 안으로 넣음
2. promises => loadTasks

### 왜 그 방법을 선택했는가? (Why)
1. 코드 리뷰 반영
2. 변수명을 명확하게 수정

### 리뷰어 참고사항

