### PR TITLE
fix(be/mail/service): 예약메일 카테고리 변경 에러 수정 #478

### DIFF
--- a/server/src/v1/mail/service.js
+++ b/server/src/v1/mail/service.js
@@ -187,7 +187,8 @@ const moveMailInInfra = async (mails, props, user) => {
   }
 
   const { name: targetBoxName } = await DB.Category.findByPk(props.category_no);
-  const messageIdsOfMailbox = await createMessageIdsByMailboxName(mails);
+  const unreservedMails = mails.filter(mail => !mail.reservation_time);
+  const messageIdsOfMailbox = await createMessageIdsByMailboxName(unreservedMails);
   Object.keys(messageIdsOfMailbox).forEach(async originBoxName => {
     moveMail({
       user,


### PR DESCRIPTION
# 무엇을 (What)
1. moveMailInInfra()에서 예약된 메일들을 필터로 걸러내고 imap 연동이 진행되도록 변경

### 왜 그 방법을 선택했는가? (Why)
1. 예약메일의 경우 imap에 존재하지 않는 메일이므로

### 리뷰어 참고사항

