### PR TITLE
fix(fe/mail-area): 메일수 변경 시 1 페이지로 설정

### DIFF
--- a/web/components/MailArea/Tools/index.js
+++ b/web/components/MailArea/Tools/index.js
@@ -98,7 +98,7 @@ const loadNewMails = async (query, dispatch, url) => {
   }
   dispatch(handleMailsChange({ ...data }));
   const { mails, paging } = data;
-  if (mails.length === 0 && paging.page !== 1) {
+  if (mails.length === 0) {
     changeUrlWithoutRunning({ ...query, page: paging.page });
   }
 };
@@ -224,7 +224,7 @@ const Tools = () => {
     if (!Number.isInteger(value)) {
       value = '';
     }
-    changeUrlWithoutRunning({ ...query, perPageNum: value });
+    changeUrlWithoutRunning({ ...query, page: 1, perPageNum: value });
   };
   const handleCheckAllChange = () => dispatch(handleCheckAllMails(allMailCheckInTools, mails));
   const handleCategoryMenuItemClick = async e => {

--- a/web/components/ReadMail/index.js
+++ b/web/components/ReadMail/index.js
@@ -90,7 +90,7 @@ const ReadMail = () => {
       mailRequest.update(mailNo, { is_read: true });
     }
     dispatch(handleMailsChange({ ...fetcher.data }));
-  }, [fetcher.data, dispatch, query.mailIndex, mail]);
+  }, [fetcher.data, dispatch, query.mailIndex]);
 
   if (fetcher.loading) {
     return <Loading />;


### PR DESCRIPTION
메일 수를 20->100으로 변경 시 총 페이지 수가 줄어들어 현재 페이지에서 메일이 존재하지 않는다는 문구가 떠서 메일수 변경 시 무조건 1페이지로 가도록 설정

