### PR TITLE
fix(fe/dialog-data): 메일함 추가하고 바로 메일 이동시키면 undefined되어 있는 버그 수정 #483

### DIFF
--- a/web/components/Aside/dialog-data.js
+++ b/web/components/Aside/dialog-data.js
@@ -1,6 +1,7 @@
 import request from '../../utils/request';
 import { errorParser } from '../../utils/error-parser';
 import { SNACKBAR_VARIANT, getSnackbarState } from '../Snackbar';
+import { changeUrlWithoutRunning } from '../../utils/url/change-query';
 
 const [ADD, MODIFY, DELETE] = [0, 1, 2];
 const url = '/mail/box/';
@@ -124,6 +125,7 @@ export const getDialogData = ({
           }
           dispatch(setCategories({ categories: categories.filter((_, index) => idx !== index) }));
           openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.DELETE);
+          changeUrlWithoutRunning();
           setDialogOpen(false);
         },
       };

--- a/web/components/Aside/dialog-data.js
+++ b/web/components/Aside/dialog-data.js
@@ -64,6 +64,7 @@ export const getDialogData = ({
             name: createdName,
             no,
           });
+          dispatch(setCategories({ categories }));
           openSnackbar(SNACKBAR_VARIANT.SUCCESS, SNACKBAR_MSG.SUCCESS.ADD);
           setDialogOpen(false);
         },


### PR DESCRIPTION
# 무엇을 (What)
1.  메일함 추가하고 메일을 바로 이동시키면 undefined로 이동된 것으로 보임

### 왜 그 방법을 선택했는가? (Why)
1. 메일함 추가될 때 전역 state의 categories를 업데이트 해주는 라인추가로 수정

### 리뷰어 참고사항
야레야레 재호가 놓치고 있었다구
